### PR TITLE
Optional note position

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,7 @@ if(${CMAKE_SYSTEM} MATCHES "Linux")
     ADD_DEFINITIONS(-D__LINUX_ALSA__)
     LINK_LIBRARIES (asound)
     LINK_LIBRARIES (pthread)
+    LINK_LIBRARIES (ncurses)
     LINK_LIBRARIES (GL)
 endif(${CMAKE_SYSTEM} MATCHES "Linux")
 

--- a/src/GuiPreferencesDialog.cpp
+++ b/src/GuiPreferencesDialog.cpp
@@ -149,6 +149,7 @@ void GuiPreferencesDialog::init(CSong* song, CSettings* settings, CGLView * glVi
     showTutorPagesCheck->setChecked(m_settings->isTutorPagesEnabled());
     followThroughErrorsCheck->setChecked(m_settings->isFollowThroughErrorsEnabled());
     showColoredNotesCheck->setChecked(m_settings->isColoredNotesEnabled());
+    showNotePositionCheck->setChecked(m_settings->isNotePositionEnabled());
 
     followStopPointCombo->setCurrentIndex(m_song->cfg_stopPointMode);
 
@@ -164,6 +165,7 @@ void GuiPreferencesDialog::accept()
     m_settings->setTutorPagesEnabled( showTutorPagesCheck->isChecked());
     m_settings->setFollowThroughErrorsEnabled( followThroughErrorsCheck->isChecked());
     m_settings->setColoredNotes( showColoredNotesCheck->isChecked());
+    m_settings->setNotePositionEnabled( showNotePositionCheck->isChecked());
     m_song->cfg_stopPointMode = static_cast<stopPointMode_t> (followStopPointCombo->currentIndex());
     m_settings->setValue("Score/StopPointMode", m_song->cfg_stopPointMode );
 

--- a/src/GuiPreferencesDialog.ui
+++ b/src/GuiPreferencesDialog.ui
@@ -31,14 +31,7 @@
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="courtesyAccidentalsCheck">
-          <property name="text">
-           <string>Courtesy Accidentals</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
+        <item row="6" column="1">
          <widget class="QComboBox" name="followStopPointCombo">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -51,38 +44,19 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label">
+        <item row="3" column="0">
+         <widget class="QCheckBox" name="followThroughErrorsCheck">
           <property name="text">
-           <string>Follow stop point:</string>
+           <string>Follow Through Errors</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <spacer name="horizontalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="courtesyAccidentalsCheck">
+          <property name="text">
+           <string>Courtesy Accidentals</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="0" column="1">
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
+         </widget>
         </item>
         <item row="2" column="0">
          <widget class="QCheckBox" name="timingMarkersCheck">
@@ -130,13 +104,6 @@
           </property>
          </spacer>
         </item>
-        <item row="3" column="0">
-         <widget class="QCheckBox" name="followThroughErrorsCheck">
-          <property name="text">
-           <string>Follow Through Errors</string>
-          </property>
-         </widget>
-        </item>
         <item row="4" column="0">
          <widget class="QCheckBox" name="showColoredNotesCheck">
           <property name="toolTip">
@@ -149,6 +116,59 @@
         </item>
         <item row="4" column="1">
          <spacer name="horizontalSpacer_5">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="1">
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Follow stop point:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="5" column="0">
+         <widget class="QCheckBox" name="showNotePositionCheck">
+          <property name="text">
+           <string>Show Note Position</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <spacer name="horizontalSpacer_6">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>

--- a/src/Piano.cpp
+++ b/src/Piano.cpp
@@ -111,7 +111,7 @@ void CPiano::drawPianoInputLines(CChord* chord, CColor color, int lineLength)
 
     for ( i = 0; i < chord->length(); i++)
     {
-        if (!m_rhythmTapping)
+        if (!m_rhythmTapping && m_settings->isNotePositionEnabled())
         {
             int pitch = chord->getNote(i).pitch();
             stavePos.notePos(chord->getNote(i).part(), pitch);

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -69,6 +69,7 @@ CSettings::CSettings(QtWindow *mainWindow) : QSettings(CSettings::IniFormat, CSe
     m_pianistActive = false;
     m_noteNamesEnabled = value("Score/NoteNames", true ).toBool();
     m_coloredNotes = value("Score/ColoredNotes", false ).toBool();
+    m_notePositionEnabled = value("Score/notePosition", true ).toBool();
     m_tutorPagesEnabled = value("Tutor/TutorPages", true ).toBool();
     CNotation::setCourtesyAccidentals(value("Score/CourtesyAccidentals", false ).toBool());
     m_followThroughErrorsEnabled = value("Score/FollowThroughErrors", false ).toBool();
@@ -100,6 +101,11 @@ void CSettings::setNoteNamesEnabled(bool value) {
 void CSettings::setColoredNotes(bool value) {
     m_coloredNotes = value;
     setValue("Score/ColoredNotes", value );
+}
+
+void CSettings::setNotePositionEnabled(bool value) {
+    m_notePositionEnabled = value;
+    setValue("Score/notePosition", value );
 }
 
 void CSettings::setTutorPagesEnabled(bool value) {

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -54,10 +54,12 @@ public:
     bool isTutorPagesEnabled() { return m_tutorPagesEnabled; }
     bool isFollowThroughErrorsEnabled() { return m_followThroughErrorsEnabled; }
     bool isColoredNotesEnabled() { return m_coloredNotes; }
+    bool isNotePositionEnabled() { return m_notePositionEnabled; }
 
     /// Saves in the .ini file whether the user wants to show the note names
     void setNoteNamesEnabled(bool value);
     void setColoredNotes(bool value);
+    void setNotePositionEnabled(bool value);
     void setTutorPagesEnabled(bool value);
     void setFollowThroughErrorsEnabled(bool value);
 
@@ -77,6 +79,13 @@ public:
     void coloredNotes(bool b){
         m_coloredNotes = b;
     }
+
+
+    /// returns true if the user wants to see vertical line at the current note
+    bool showNotePosition(){
+        return m_notePositionEnabled;
+    }
+
 
     /// returns true if the user wants Follow Skill to ignore errors
     bool followThroughErrors(){
@@ -199,6 +208,7 @@ private:
     GuiTopBar* m_guiTopBar;
     bool m_noteNamesEnabled;
     bool m_coloredNotes;
+    bool m_notePositionEnabled;
     bool m_tutorPagesEnabled;
     bool m_advancedMode;
     bool m_followThroughErrorsEnabled;


### PR DESCRIPTION
Hi everyone,  
I've added an additional checkbox to the preferences dialogue that toggles the orientation of the small blue bar (the one that indicates the position of the played key). This way the user can choose between getting hints on the position of the note that he/she just played or not.. 
If you consider this a useful feature, feel free to merge, edit or point out mistakes.
Ah, and I added the ncurses library to the CMakeLists.txt since I was not able to build the app on Ubuntu 20.04 without it..
Best,
Hendrik