### PR TITLE
Fixes and documentation for building on ARM devices

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -72,6 +72,41 @@ Once this is completed type:
 
 Or alternatively you can install QtCreator and then open the `CMakeLists.txt`.
 
+# Build instructions for Raspberry PI OS and other ARM Devices
+
+Building on these devices requires QT compiled with desktop OpenGL support. OpenGL/ES is not supported at this time. If after compiling and running PianoBooster you see messages concerning OpenGL/ES like this:
+
+```
+QGLWidget::renderText is not supported under OpenGL/ES
+```
+
+it means that your version of QTOpenGL will not support PianoBooster. To fix this you must obtain an alternate package from your distribtion or compile your own version of QT with desktop opengl support. For instructions on building QT5, please read the [QT5 Linux Building Instructions](https://doc.qt.io/qt-5/linux-building.html)
+
+Use the following command on the configure step:
+```
+./configure -opensource -opengl desktop
+```
+
+After building and installing QT, you can build PianoBooster with the above Linux and BSD Unix steps.  If you wish to install your QT in a prefix then you can set `$LD_LIBRARY_PATH` to `$QTPREFIX/lib` and then run it.
+
+# Building an AppImage
+
+For compatility reasons, it is recommended to build the AppImage on the oldest still supported distribution that you can assume users still use.
+
+This can be accomplished by first installing packages specified in the Linux and BSD Unix steps above. You will also need [linuxdeploy](https://github.com/linuxdeploy/linuxdeploy). You can use the appimage or build it yourself. To build the PianoBooster appimage run:
+
+```
+$ mkdir build
+$ cd build
+$ cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
+$ make
+$ make install DESTDIR=AppDir
+
+$ linuxdeploy --appdir=AppDir --output appimage
+or
+$ linuxdeploy --appdir=AppDir && linuxdeploy-plugin-appimage --appdir=AppDir
+```
+
 # Build options
 
 Using `cmake` without any flags defaults to the recommended build options.

--- a/BUILD.md
+++ b/BUILD.md
@@ -87,7 +87,7 @@ Use the following command on the configure step:
 ./configure -opensource -opengl desktop
 ```
 
-After building and installing QT, you can build PianoBooster with the above Linux and BSD Unix steps.  If you wish to install your QT in a prefix then you can set `$LD_LIBRARY_PATH` to `$QTPREFIX/lib` and then run it.
+After building and installing QT, you can build PianoBooster with the above Linux and BSD Unix steps.  If you installed your QT in a prefix then you can set `$LD_LIBRARY_PATH` to `$QTPREFIX/lib` and then run it.
 
 # Building an AppImage
 
@@ -102,9 +102,9 @@ $ cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
 $ make
 $ make install DESTDIR=AppDir
 
-$ linuxdeploy --appdir=AppDir --output appimage
-or
-$ linuxdeploy --appdir=AppDir && linuxdeploy-plugin-appimage --appdir=AppDir
+$ linuxdeploy --appdir=AppDir --plugin qt --output appimage
+or (if built separately)
+$ linuxdeploy --appdir=AppDir && linuxdeploy-plugin-qt --appdir=AppDir && linuxdeploy-plugin-appimage --appdir=AppDir
 ```
 
 # Build options

--- a/src/Cfg.cpp
+++ b/src/Cfg.cpp
@@ -42,6 +42,7 @@ int Cfg::keyboardLightsChan = -1;
 
 int Cfg::experimentalSwapInterval = -1;
 int Cfg::tickRate;
+int Cfg::samplesPerPixel;
 
 const int Cfg::m_playZoneEarly = 25; // Was 25
 const int Cfg::m_playZoneLate = 25;

--- a/src/Cfg.h
+++ b/src/Cfg.h
@@ -113,6 +113,13 @@ public:
     #else
           tickRate = 4; // was 12
     #endif
+
+    #if defined (Q_PROCESSOR_ARM)
+          // Multi sampling anti aliasing does not work well on devices like the Raspberry PI
+          samplesPerPixel = -1;
+    #else
+          samplesPerPixel = 4;
+    #endif
     }
 
     static void setStaveEndX(float x)
@@ -138,6 +145,7 @@ public:
     static bool experimentalTempo;
     static bool experimentalNoteLength;
     static int experimentalSwapInterval;
+    static int samplesPerPixel;
     static int tickRate;
     static bool useLogFile;
     static bool midiInputDump;

--- a/src/QtWindow.cpp
+++ b/src/QtWindow.cpp
@@ -79,9 +79,8 @@ QtWindow::QtWindow()
     set_realtime_priority(SCHED_FIFO, rt_prio);
 #endif
 
-    QString antiAliasingSetting = m_settings->value("anti-aliasing").toString();
-    if (antiAliasingSetting.isEmpty() || antiAliasingSetting=="on"){
-        fmt.setSamples(4);
+    if (Cfg::samplesPerPixel != -1) {
+        fmt.setSamples(Cfg::samplesPerPixel);
     }
 
     QGLFormat::setDefaultFormat(fmt);


### PR DESCRIPTION
- Move the anti-aliasing setting to the Cfg class instead of a user setting and disable it on arm for now.
- Write build documentation for building on the Raspberry PI/ARM devices and about how to build an AppImage.