### PR TITLE
Add preferences option that adjusts size of staves/keyboard

### DIFF
--- a/src/Cfg.cpp
+++ b/src/Cfg.cpp
@@ -29,6 +29,7 @@
 #include "Cfg.h"
 
 float Cfg::m_staveEndX;
+float Cfg::m_scalingFactor;
 int Cfg::logLevel = LOG_LEVEL_INFO;
 int Cfg::m_appX;
 int Cfg::m_appY;

--- a/src/Cfg.h
+++ b/src/Cfg.h
@@ -72,16 +72,16 @@ public:
 class Cfg
 {
 public:
-    static float staveStartX()         {return 20;}
+    static float staveStartX()         {return 20 * m_scalingFactor;}
     static float staveEndX()           {return m_staveEndX;}
-    static float playZoneX()           {return scrollStartX() + ( staveEndX() - scrollStartX())* 0.4f;}
-    static float clefX()               {return staveStartX() + 20;}
-    static float timeSignatureX()       {return clefX() + 25;}
-    static float keySignatureX()       {return timeSignatureX() + 25;}
-    static float scrollStartX()        {return keySignatureX() + 64;}
-    static float pianoX()              {return 25;}
+    static float playZoneX()           {return scrollStartX() + ( staveEndX() - scrollStartX())* 0.4f * m_scalingFactor;}
+    static float clefX()               {return staveStartX() + 20 * m_scalingFactor;}
+    static float timeSignatureX()       {return clefX() + 25 * m_scalingFactor;}
+    static float keySignatureX()       {return timeSignatureX() + 25 * m_scalingFactor;}
+    static float scrollStartX()        {return keySignatureX() + 64 * m_scalingFactor;}
+    static float pianoX()              {return 25 * m_scalingFactor;}
 
-    static float staveThickness()      {return 1;}
+    static float staveThickness()      {return 1 * m_scalingFactor;}
 
     static int playZoneEarly()     {return m_playZoneEarly;}
     static int playZoneLate()      {return m_playZoneLate;}
@@ -143,11 +143,17 @@ public:
     static bool midiInputDump;
     static int keyboardLightsChan;
 
+    static void setScalingFactor(float scalingFactor)
+    {
+        m_scalingFactor = scalingFactor;
+    }
+
 private:
     static float m_staveEndX;
     static int m_appX, m_appY, m_appWidth, m_appHeight;
     static const int m_playZoneEarly;
     static const int m_playZoneLate;
+    static float m_scalingFactor;
 };
 
 #endif //__CFG_H__

--- a/src/Cfg.h
+++ b/src/Cfg.h
@@ -148,6 +148,11 @@ public:
         m_scalingFactor = scalingFactor;
     }
 
+    static float getScalingFactor()
+    {
+        return m_scalingFactor;
+    }
+
 private:
     static float m_staveEndX;
     static int m_appX, m_appY, m_appWidth, m_appHeight;

--- a/src/Draw.cpp
+++ b/src/Draw.cpp
@@ -42,6 +42,10 @@ CDraw::CDraw(CSettings* settings)
     :font(nullptr)
 #endif
 {
+    m_settings = settings;
+    m_displayHand = PB_PART_both;
+    m_forceCompileRedraw = 1;
+    m_scrollProperties = &m_scrollPropertiesHorizontal;
 #ifndef NO_USE_FTGL
     QStringList listPathFonts;
 
@@ -66,13 +70,16 @@ CDraw::CDraw(CSettings* settings)
         ppLogError("Font DejaVuSans.ttf was not found !");
         exit(0);
     }
-    font->FaceSize(FONT_SIZE, FONT_SIZE);
+    refreshFontSize();
 #endif
-    m_settings = settings;
-    m_displayHand = PB_PART_both;
-    m_forceCompileRedraw = 1;
-    m_scrollProperties = &m_scrollPropertiesHorizontal;
 }
+
+#ifndef NO_USE_FTGL
+void CDraw::refreshFontSize() {
+    int fontSize = static_cast<int>(FONT_SIZE * m_settings->scalingFactor());
+    font->FaceSize(fontSize);
+}
+#endif
 
 void CDraw::oneLine(float x1, float y1, float x2, float y2)
 {
@@ -139,6 +146,7 @@ void CDraw::drawNoteName(int midiNote, float x, float y, int type)
     glLineWidth (1.0);
 
 #ifdef NO_USE_FTGL
+    float sf = m_settings->scalingFactor();
     if (item.accidental != 0)
       {
           const float accidentalOffset = 10;
@@ -147,14 +155,14 @@ void CDraw::drawNoteName(int midiNote, float x, float y, int type)
           {
               glBegin(GL_LINES);
                   //  letterSharp4
-                  scaleGlVertex( -1.317895, x,   5.794585, y);  //  1
-                  scaleGlVertex( -1.265845, x,   -6.492455, y);  //  2
-                  scaleGlVertex( 1.252305, x,   6.492455, y);  //  3
-                  scaleGlVertex( 1.322655, x,   -5.422335, y);  //  4
-                  scaleGlVertex( -2.645765, x,   1.967805, y);  //  5
-                  scaleGlVertex( 2.648325, x,   3.625485, y);  //  6
-                  scaleGlVertex( -2.648325, x,   -3.306965, y);  //  7
-                  scaleGlVertex( 2.596205, x,   -1.675765, y);  //  8
+                  scaleGlVertex( -1.317895, x * sf,   5.794585, y * sf);  //  1
+                  scaleGlVertex( -1.265845, x * sf,   -6.492455, y * sf);  //  2
+                  scaleGlVertex( 1.252305, x * sf,   6.492455, y * sf);  //  3
+                  scaleGlVertex( 1.322655, x * sf,   -5.422335, y * sf);  //  4
+                  scaleGlVertex( -2.645765, x * sf,   1.967805, y * sf);  //  5
+                  scaleGlVertex( 2.648325, x * sf,   3.625485, y * sf);  //  6
+                  scaleGlVertex( -2.648325, x * sf,   -3.306965, y * sf);  //  7
+                  scaleGlVertex( 2.596205, x * sf,   -1.675765, y * sf);  //  8
               glEnd();
 
           }
@@ -162,15 +170,15 @@ void CDraw::drawNoteName(int midiNote, float x, float y, int type)
           {
               glBegin(GL_LINE_STRIP);
                   //  letterFlat
-                  scaleGlVertex( -2.52933, x,   6.25291, y);  //  1
-                  scaleGlVertex( -2.50344, x,   -6.25291, y);  //  2
-                  scaleGlVertex( 0.76991, x,   -3.63422, y);  //  3
-                  scaleGlVertex( 2.07925, x,   -1.67021, y);  //  4
-                  scaleGlVertex( 2.52933, x,   0.25288, y);  //  5
-                  scaleGlVertex( 1.42458, x,   1.07122, y);  //  6
-                  scaleGlVertex( -0.53943, x,   0.90755, y);  //  7
-                  scaleGlVertex( -2.46252, x,   -1.01554, y);  //  8
-                  scaleGlVertex( -2.50344, x,   -1.67021, y);  //  9
+                  scaleGlVertex( -2.52933, x * sf,   6.25291, y * sf);  //  1
+                  scaleGlVertex( -2.50344, x * sf,   -6.25291, y * sf);  //  2
+                  scaleGlVertex( 0.76991, x * sf,   -3.63422, y * sf);  //  3
+                  scaleGlVertex( 2.07925, x * sf,   -1.67021, y * sf);  //  4
+                  scaleGlVertex( 2.52933, x * sf,   0.25288, y * sf);  //  5
+                  scaleGlVertex( 1.42458, x * sf,   1.07122, y * sf);  //  6
+                  scaleGlVertex( -0.53943, x * sf,   0.90755, y * sf);  //  7
+                  scaleGlVertex( -2.46252, x * sf,   -1.01554, y * sf);  //  8
+                  scaleGlVertex( -2.50344, x * sf,   -1.67021, y * sf);  //  9
               glEnd();
 
           }
@@ -182,54 +190,54 @@ void CDraw::drawNoteName(int midiNote, float x, float y, int type)
       case 1:
           glBegin(GL_LINE_STRIP);
               //  letterC
-              scaleGlVertex( 3.513445, x,   2.17485, y);  //  1
-              scaleGlVertex( 1.880175, x,   4.47041, y);  //  2
-              scaleGlVertex( -1.598825, x,   4.4321, y);  //  3
-              scaleGlVertex( -3.692215, x,   2.26571, y);  //  4
-              scaleGlVertex( -3.702055, x,   -1.88958, y);  //  5
-              scaleGlVertex( -1.630675, x,   -4.47041, y);  //  6
-              scaleGlVertex( 1.932545, x,   -4.44064, y);  //  7
-              scaleGlVertex( 3.702055, x,   -1.88554, y);  //  8
+              scaleGlVertex( 3.513445, x * sf,   2.17485, y * sf);  //  1
+              scaleGlVertex( 1.880175, x * sf,   4.47041, y * sf);  //  2
+              scaleGlVertex( -1.598825, x * sf,   4.4321, y * sf);  //  3
+              scaleGlVertex( -3.692215, x * sf,   2.26571, y * sf);  //  4
+              scaleGlVertex( -3.702055, x * sf,   -1.88958, y * sf);  //  5
+              scaleGlVertex( -1.630675, x * sf,   -4.47041, y * sf);  //  6
+              scaleGlVertex( 1.932545, x * sf,   -4.44064, y * sf);  //  7
+              scaleGlVertex( 3.702055, x * sf,   -1.88554, y * sf);  //  8
           glEnd();
       break;
 
       case 2:
           glBegin(GL_LINE_STRIP);
               //  letterD
-              scaleGlVertex( -3.30696, x,   4.31878, y);  //  1
-              scaleGlVertex( -3.3428, x,   -4.31878, y);  //  2
-              scaleGlVertex( 0.9425, x,   -4.28164, y);  //  3
-              scaleGlVertex( 3.31415, x,   -1.42302, y);  //  4
-              scaleGlVertex( 3.3428, x,   1.66626, y);  //  5
-              scaleGlVertex( 0.70825, x,   4.31317, y);  //  6
-              scaleGlVertex( -3.22083, x,   4.29495, y);  //  7
+              scaleGlVertex( -3.30696, x * sf,   4.31878, y * sf);  //  1
+              scaleGlVertex( -3.3428, x * sf,   -4.31878, y * sf);  //  2
+              scaleGlVertex( 0.9425, x * sf,   -4.28164, y * sf);  //  3
+              scaleGlVertex( 3.31415, x * sf,   -1.42302, y * sf);  //  4
+              scaleGlVertex( 3.3428, x * sf,   1.66626, y * sf);  //  5
+              scaleGlVertex( 0.70825, x * sf,   4.31317, y * sf);  //  6
+              scaleGlVertex( -3.22083, x * sf,   4.29495, y * sf);  //  7
           glEnd();
       break;
 
       case 3: // E
           glBegin(GL_LINE_STRIP);
               //  letterE2
-              scaleGlVertex( 2.966065, x,   4.416055, y);  //  1
-              scaleGlVertex( -3.007275, x,   4.403495, y);  //  2
-              scaleGlVertex( -3.037615, x,   -4.416055, y);  //  3
-              scaleGlVertex( 3.037615, x,   -4.415435, y);  //  4
+              scaleGlVertex( 2.966065, x * sf,   4.416055, y * sf);  //  1
+              scaleGlVertex( -3.007275, x * sf,   4.403495, y * sf);  //  2
+              scaleGlVertex( -3.037615, x * sf,   -4.416055, y * sf);  //  3
+              scaleGlVertex( 3.037615, x * sf,   -4.415435, y * sf);  //  4
           glEnd();
           glBegin(GL_LINES);
-              scaleGlVertex( 3.011705, x,   0.197675, y);  //  5
-              scaleGlVertex( -2.990845, x,   0.196615, y);  //  6
+              scaleGlVertex( 3.011705, x * sf,   0.197675, y * sf);  //  5
+              scaleGlVertex( -2.990845, x * sf,   0.196615, y * sf);  //  6
           glEnd();
       break;
 
       case 4: // F
           glBegin(GL_LINE_STRIP);
               //  letterF2
-              scaleGlVertex( -2.55172, x,   -4.434285, y);  //  1
-              scaleGlVertex( -2.51956, x,   4.433665, y);  //  2
-              scaleGlVertex( 2.39942, x,   4.434285, y);  //  3
+              scaleGlVertex( -2.55172, x * sf,   -4.434285, y * sf);  //  1
+              scaleGlVertex( -2.51956, x * sf,   4.433665, y * sf);  //  2
+              scaleGlVertex( 2.39942, x * sf,   4.434285, y * sf);  //  3
           glEnd();
           glBegin(GL_LINES);
-              scaleGlVertex( 2.58143, x,   0.244465, y);  //  4
-              scaleGlVertex( -2.58143, x,   0.243405, y);  //  5
+              scaleGlVertex( 2.58143, x * sf,   0.244465, y * sf);  //  4
+              scaleGlVertex( -2.58143, x * sf,   0.243405, y * sf);  //  5
 
           glEnd();
       break;
@@ -237,29 +245,29 @@ void CDraw::drawNoteName(int midiNote, float x, float y, int type)
       case 5:
           glBegin(GL_LINE_STRIP);
               //  letterG
-              scaleGlVertex( 0.58123, x,   -0.34005, y);  //  1
-              scaleGlVertex( 3.66047, x,   -0.48722, y);  //  2
-              scaleGlVertex( 3.70461, x,   -3.23595, y);  //  3
-              scaleGlVertex( 1.96234, x,   -4.41694, y);  //  4
-              scaleGlVertex( -0.96712, x,   -4.57846, y);  //  5
-              scaleGlVertex( -3.70461, x,   -2.29011, y);  //  6
-              scaleGlVertex( -3.67245, x,   2.14034, y);  //  7
-              scaleGlVertex( -1.25347, x,   4.57846, y);  //  8
-              scaleGlVertex( 1.90018, x,   4.55293, y);  //  9
-              scaleGlVertex( 3.54236, x,   2.38612, y);  //  10
+              scaleGlVertex( 0.58123, x * sf,   -0.34005, y * sf);  //  1
+              scaleGlVertex( 3.66047, x * sf,   -0.48722, y * sf);  //  2
+              scaleGlVertex( 3.70461, x * sf,   -3.23595, y * sf);  //  3
+              scaleGlVertex( 1.96234, x * sf,   -4.41694, y * sf);  //  4
+              scaleGlVertex( -0.96712, x * sf,   -4.57846, y * sf);  //  5
+              scaleGlVertex( -3.70461, x * sf,   -2.29011, y * sf);  //  6
+              scaleGlVertex( -3.67245, x * sf,   2.14034, y * sf);  //  7
+              scaleGlVertex( -1.25347, x * sf,   4.57846, y * sf);  //  8
+              scaleGlVertex( 1.90018, x * sf,   4.55293, y * sf);  //  9
+              scaleGlVertex( 3.54236, x * sf,   2.38612, y * sf);  //  10
           glEnd();
       break;
 
       case 6: // A
           glBegin(GL_LINE_STRIP);
               //  letterA2
-              scaleGlVertex( -3.91146, x,   -4.907395, y);  //  1
-              scaleGlVertex( 0.06571, x,   4.907395, y);  //  2
-              scaleGlVertex( 3.91146, x,   -4.803315, y);  //  3
+              scaleGlVertex( -3.91146, x * sf,   -4.907395, y * sf);  //  1
+              scaleGlVertex( 0.06571, x * sf,   4.907395, y * sf);  //  2
+              scaleGlVertex( 3.91146, x * sf,   -4.803315, y * sf);  //  3
           glEnd();
           glBegin(GL_LINES);
-              scaleGlVertex( 2.60111, x,   -1.400435, y);  //  4
-              scaleGlVertex( -2.56175, x,   -1.357305, y);  //  5
+              scaleGlVertex( 2.60111, x * sf,   -1.400435, y * sf);  //  4
+              scaleGlVertex( -2.56175, x * sf,   -1.357305, y * sf);  //  5
 
           glEnd();
       break;
@@ -267,18 +275,18 @@ void CDraw::drawNoteName(int midiNote, float x, float y, int type)
       case 7:
           glBegin(GL_LINE_STRIP);
               //  letterB
-              scaleGlVertex( 1.038555, x,   0.105285, y);  //  1
-              scaleGlVertex( -3.001935, x,   0.121925, y);  //  2
-              scaleGlVertex( -3.027615, x,   4.417905, y);  //  3
-              scaleGlVertex( 1.325925, x,   4.451255, y);  //  4
-              scaleGlVertex( 2.737985, x,   3.048615, y);  //  5
-              scaleGlVertex( 2.721765, x,   1.366235, y);  //  6
-              scaleGlVertex( 1.022635, x,   0.120235, y);  //  7
-              scaleGlVertex( 3.026015, x,   -1.282295, y);  //  8
-              scaleGlVertex( 3.027615, x,   -3.046285, y);  //  9
-              scaleGlVertex( 1.176815, x,   -4.451255, y);  //  10
-              scaleGlVertex( -2.981475, x,   -4.445735, y);  //  11
-              scaleGlVertex( -3.021355, x,   0.176035, y);  //  12
+              scaleGlVertex( 1.038555, x * sf,   0.105285, y * sf);  //  1
+              scaleGlVertex( -3.001935, x * sf,   0.121925, y * sf);  //  2
+              scaleGlVertex( -3.027615, x * sf,   4.417905, y * sf);  //  3
+              scaleGlVertex( 1.325925, x * sf,   4.451255, y * sf);  //  4
+              scaleGlVertex( 2.737985, x * sf,   3.048615, y * sf);  //  5
+              scaleGlVertex( 2.721765, x * sf,   1.366235, y * sf);  //  6
+              scaleGlVertex( 1.022635, x * sf,   0.120235, y * sf);  //  7
+              scaleGlVertex( 3.026015, x * sf,   -1.282295, y * sf);  //  8
+              scaleGlVertex( 3.027615, x * sf,   -3.046285, y * sf);  //  9
+              scaleGlVertex( 1.176815, x * sf,   -4.451255, y * sf);  //  10
+              scaleGlVertex( -2.981475, x * sf,   -4.445735, y * sf);  //  11
+              scaleGlVertex( -3.021355, x * sf,   0.176035, y * sf);  //  12
           glEnd();
       break;
 
@@ -340,14 +348,14 @@ void CDraw::drawStaveNoteName(CSymbol symbol, float x, float y)
         return;
     if (m_settings->showNoteNames() == false)
         return;
-    y += CStavePos::getVerticalNoteSpacing()*2 +3;
+    y += CStavePos::verticalNoteSpacing()*2 +3;
     drawNoteName(symbol.getNote(), x, y, true);
 }
 
 void CDraw::checkAccidental(CSymbol symbol, float x, float y)
 {
     int accidental;
-    const int xGap = 16;
+    const int xGap = 16 * m_settings->scalingFactor();
 
     accidental = symbol.getStavePos().getAccidental();
 
@@ -376,8 +384,8 @@ void CDraw::checkAccidental(CSymbol symbol, float x, float y)
 
 bool CDraw::drawNote(CSymbol* symbol, float x, float y, CSlot* slot, CColor color, bool playable)
 {
-    const float stemLength  = 34.0;
-    float noteWidth  = 6.0;
+    const float stemLength  = 34.0 * m_settings->scalingFactor();
+    float noteWidth  = 6.0 * m_settings->scalingFactor();
 
     //ppLogTrace("PB_SYMBOL_noteHead x %f y %f", x, y);
     if (!CChord::isNotePlayable(symbol->getNote(), 0))
@@ -469,6 +477,7 @@ bool CDraw::drawNote(CSymbol* symbol, float x, float y, CSlot* slot, CColor colo
 
 void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
 {
+    float sf = m_settings->scalingFactor();
     CColor color = symbol.getColor();
     bool playable = true;
 
@@ -488,55 +497,55 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
             drColor(color);
             glLineWidth (3.0);
             glBegin(GL_LINE_STRIP);
-            glVertex2f( -0.011922  + x,   -16.11494  + y);  //  1
-            glVertex2f( -3.761922  + x,   -12.48994  + y);  //  2
-            glVertex2f( -4.859633  + x,   -8.85196  + y);  //  3
-            glVertex2f( -4.783288  + x,   -5.42815  + y);  //  4
-            glVertex2f( -0.606711  + x,   -1.11108  + y);  //  5
-            glVertex2f( 5.355545  + x,   0.48711  + y);  //  6
-            glVertex2f( 10.641104  + x,   -1.6473  + y);  //  7
-            glVertex2f( 14.293812  + x,   -6.18241  + y);  //  8
-            glVertex2f( 14.675578  + x,   -11.42744  + y);  //  9
-            glVertex2f( 12.550578  + x,   -17.30244  + y);  //  10
-            glVertex2f( 7.912166  + x,   -20.944  + y);  //  11
-            glVertex2f( 3.049705  + x,   -21.65755  + y);  //  12
-            glVertex2f( -1.711005  + x,   -21.36664  + y);  //  13
-            glVertex2f( -6.283661  + x,   -19.66739  + y);  //  14
-            glVertex2f( -10.123329  + x,   -16.79162  + y);  //  15
-            glVertex2f( -13.363008  + x,   -12.28184  + y);  //  16
-            glVertex2f( -14.675578  + x,   -5.79969  + y);  //  17
-            glVertex2f( -13.66821  + x,   0.20179  + y);  //  18
-            glVertex2f( -10.385341  + x,   6.27562  + y);  //  19
-            glVertex2f( 5.539491  + x,   20.32671  + y);  //  20
-            glVertex2f( 10.431588  + x,   28.20584  + y);  //  21
-            glVertex2f( 11.00141  + x,   34.71585  + y);  //  22
-            glVertex2f( 9.204915  + x,   39.62875  + y);  //  23
-            glVertex2f( 7.854166  + x,   42.08262  + y);  //  24
-            glVertex2f( 5.481415  + x,   42.66649  + y);  //  25
-            glVertex2f( 3.57972  + x,   41.4147  + y);  //  26
-            glVertex2f( 1.507889  + x,   37.35642  + y);  //  27
-            glVertex2f( -0.381338  + x,   31.14317  + y);  //  28
-            glVertex2f( -0.664306  + x,   25.51354  + y);  //  29
-            glVertex2f( 8.296044  + x,   -32.22694  + y);  //  30
-            glVertex2f( 8.050507  + x,   -36.6687  + y);  //  31
-            glVertex2f( 6.496615  + x,   -39.52999  + y);  //  32
-            glVertex2f( 3.368583  + x,   -41.7968  + y);  //  33
-            glVertex2f( 0.253766  + x,   -42.66649  + y);  //  34
-            glVertex2f( -3.599633  + x,   -42.23514  + y);  //  35
-            glVertex2f( -8.098754  + x,   -39.46637  + y);  //  36
-            glVertex2f( -9.463279  + x,   -35.49796  + y);  //  37
-            glVertex2f( -7.08037  + x,   -31.36512  + y);  //  38
-            glVertex2f( -3.336421  + x,   -31.14057  + y);  //  39
-            glVertex2f( -1.360313  + x,   -34.07738  + y);  //  40
-            glVertex2f( -1.608342  + x,   -37.11828  + y);  //  41
-            glVertex2f( -5.729949  + x,   -39.24759  + y);  //  42
-            glVertex2f( -7.480646  + x,   -36.2136  + y);  //  43
-            glVertex2f( -6.826918  + x,   -33.36919  + y);  //  44
-            glVertex2f( -4.069083  + x,   -32.9226  + y);  //  45
-            glVertex2f( -3.040669  + x,   -34.433  + y);  //  46
-            glVertex2f( -3.737535  + x,   -36.38759  + y);  //  47
-            glVertex2f( -5.496558  + x,   -36.97633  + y);  //  48
-            glVertex2f( -5.295932  + x,   -34.01951  + y);  //  49
+            glVertex2f( -0.011922  * sf + x,   -16.11494  * sf + y);  //  1
+            glVertex2f( -3.761922  * sf + x,   -12.48994  * sf + y);  //  2
+            glVertex2f( -4.859633  * sf + x,   -8.85196  * sf + y);  //  3
+            glVertex2f( -4.783288  * sf + x,   -5.42815  * sf + y);  //  4
+            glVertex2f( -0.606711  * sf + x,   -1.11108  * sf + y);  //  5
+            glVertex2f( 5.355545  * sf + x,   0.48711  * sf + y);  //  6
+            glVertex2f( 10.641104  * sf + x,   -1.6473  * sf + y);  //  7
+            glVertex2f( 14.293812  * sf + x,   -6.18241  * sf + y);  //  8
+            glVertex2f( 14.675578  * sf + x,   -11.42744  * sf + y);  //  9
+            glVertex2f( 12.550578  * sf + x,   -17.30244  * sf + y);  //  10
+            glVertex2f( 7.912166  * sf + x,   -20.944  * sf + y);  //  11
+            glVertex2f( 3.049705  * sf + x,   -21.65755  * sf + y);  //  12
+            glVertex2f( -1.711005  * sf + x,   -21.36664  * sf + y);  //  13
+            glVertex2f( -6.283661  * sf + x,   -19.66739  * sf + y);  //  14
+            glVertex2f( -10.123329  * sf + x,   -16.79162  * sf + y);  //  15
+            glVertex2f( -13.363008  * sf + x,   -12.28184  * sf + y);  //  16
+            glVertex2f( -14.675578  * sf + x,   -5.79969  * sf + y);  //  17
+            glVertex2f( -13.66821  * sf + x,   0.20179  * sf + y);  //  18
+            glVertex2f( -10.385341  * sf + x,   6.27562  * sf + y);  //  19
+            glVertex2f( 5.539491  * sf + x,   20.32671  * sf + y);  //  20
+            glVertex2f( 10.431588  * sf + x,   28.20584  * sf + y);  //  21
+            glVertex2f( 11.00141  * sf + x,   34.71585  * sf + y);  //  22
+            glVertex2f( 9.204915  * sf + x,   39.62875  * sf + y);  //  23
+            glVertex2f( 7.854166  * sf + x,   42.08262  * sf + y);  //  24
+            glVertex2f( 5.481415  * sf + x,   42.66649  * sf + y);  //  25
+            glVertex2f( 3.57972  * sf + x,   41.4147  * sf + y);  //  26
+            glVertex2f( 1.507889  * sf + x,   37.35642  * sf + y);  //  27
+            glVertex2f( -0.381338  * sf + x,   31.14317  * sf + y);  //  28
+            glVertex2f( -0.664306  * sf + x,   25.51354  * sf + y);  //  29
+            glVertex2f( 8.296044  * sf + x,   -32.22694  * sf + y);  //  30
+            glVertex2f( 8.050507  * sf + x,   -36.6687  * sf + y);  //  31
+            glVertex2f( 6.496615  * sf + x,   -39.52999  * sf + y);  //  32
+            glVertex2f( 3.368583  * sf + x,   -41.7968  * sf + y);  //  33
+            glVertex2f( 0.253766  * sf + x,   -42.66649  * sf + y);  //  34
+            glVertex2f( -3.599633  * sf + x,   -42.23514  * sf + y);  //  35
+            glVertex2f( -8.098754  * sf + x,   -39.46637  * sf + y);  //  36
+            glVertex2f( -9.463279  * sf + x,   -35.49796  * sf + y);  //  37
+            glVertex2f( -7.08037  * sf + x,   -31.36512  * sf + y);  //  38
+            glVertex2f( -3.336421  * sf + x,   -31.14057  * sf + y);  //  39
+            glVertex2f( -1.360313  * sf + x,   -34.07738  * sf + y);  //  40
+            glVertex2f( -1.608342  * sf + x,   -37.11828  * sf + y);  //  41
+            glVertex2f( -5.729949  * sf + x,   -39.24759  * sf + y);  //  42
+            glVertex2f( -7.480646  * sf + x,   -36.2136  * sf + y);  //  43
+            glVertex2f( -6.826918  * sf + x,   -33.36919  * sf + y);  //  44
+            glVertex2f( -4.069083  * sf + x,   -32.9226  * sf + y);  //  45
+            glVertex2f( -3.040669  * sf + x,   -34.433  * sf + y);  //  46
+            glVertex2f( -3.737535  * sf + x,   -36.38759  * sf + y);  //  47
+            glVertex2f( -5.496558  * sf + x,   -36.97633  * sf + y);  //  48
+            glVertex2f( -5.295932  * sf + x,   -34.01951  * sf + y);  //  49
 
             glEnd();
 
@@ -546,47 +555,47 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
             drColor(color);
             glLineWidth (3.0);
             glBegin(GL_LINE_STRIP);
-                glVertex2f( -15.370325  + x,   -17.42068  + y);  //  1
-                glVertex2f( -7.171025  + x,   -13.75432  + y);  //  2
-                glVertex2f( -2.867225  + x,   -10.66642  + y);  //  3
-                glVertex2f( 0.925165  + x,   -7.03249  + y);  //  4
-                glVertex2f( 4.254425  + x,   -0.65527  + y);  //  5
-                glVertex2f( 4.762735  + x,   7.77848  + y);  //  6
-                glVertex2f( 2.693395  + x,   13.92227  + y);  //  7
-                glVertex2f( -1.207935  + x,   16.80317  + y);  //  8
-                glVertex2f( -5.526425  + x,   17.42068  + y);  //  9
-                glVertex2f( -10.228205  + x,   15.65609  + y);  //  10
-                glVertex2f( -13.453995  + x,   10.7128  + y);  //  11
-                glVertex2f( -13.133655  + x,   5.43731  + y);  //  12
-                glVertex2f( -9.475575  + x,   3.00714  + y);  //  13
-                glVertex2f( -5.846445  + x,   4.72159  + y);  //  14
-                glVertex2f( -5.395545  + x,   9.72918  + y);  //  15
-                glVertex2f( -8.850025  + x,   11.64372  + y);  //  16
-                glVertex2f( -11.519385  + x,   10.35816  + y);  //  17
-                glVertex2f( -11.706365  + x,   6.8704  + y);  //  18
-                glVertex2f( -9.463505  + x,   5.01391  + y);  //  19
-                glVertex2f( -7.172075  + x,   5.81649  + y);  //  20
-                glVertex2f( -7.189565  + x,   8.62975  + y);  //  21
-                glVertex2f( -9.175055  + x,   9.82019  + y);  //  22
-                glVertex2f( -10.696425  + x,   8.08395  + y);  //  23
-                glVertex2f( -8.843065  + x,   6.66726  + y);  //  24
-                glVertex2f( -8.995775  + x,   8.71136  + y);  //  25
+                glVertex2f( -15.370325  * sf + x,   -17.42068  * sf + y);  //  1
+                glVertex2f( -7.171025  * sf + x,   -13.75432  * sf + y);  //  2
+                glVertex2f( -2.867225  * sf + x,   -10.66642  * sf + y);  //  3
+                glVertex2f( 0.925165  * sf + x,   -7.03249  * sf + y);  //  4
+                glVertex2f( 4.254425  * sf + x,   -0.65527  * sf + y);  //  5
+                glVertex2f( 4.762735  * sf + x,   7.77848  * sf + y);  //  6
+                glVertex2f( 2.693395  * sf + x,   13.92227  * sf + y);  //  7
+                glVertex2f( -1.207935  * sf + x,   16.80317  * sf + y);  //  8
+                glVertex2f( -5.526425  * sf + x,   17.42068  * sf + y);  //  9
+                glVertex2f( -10.228205  * sf + x,   15.65609  * sf + y);  //  10
+                glVertex2f( -13.453995  * sf + x,   10.7128  * sf + y);  //  11
+                glVertex2f( -13.133655  * sf + x,   5.43731  * sf + y);  //  12
+                glVertex2f( -9.475575  * sf + x,   3.00714  * sf + y);  //  13
+                glVertex2f( -5.846445  * sf + x,   4.72159  * sf + y);  //  14
+                glVertex2f( -5.395545  * sf + x,   9.72918  * sf + y);  //  15
+                glVertex2f( -8.850025  * sf + x,   11.64372  * sf + y);  //  16
+                glVertex2f( -11.519385  * sf + x,   10.35816  * sf + y);  //  17
+                glVertex2f( -11.706365  * sf + x,   6.8704  * sf + y);  //  18
+                glVertex2f( -9.463505  * sf + x,   5.01391  * sf + y);  //  19
+                glVertex2f( -7.172075  * sf + x,   5.81649  * sf + y);  //  20
+                glVertex2f( -7.189565  * sf + x,   8.62975  * sf + y);  //  21
+                glVertex2f( -9.175055  * sf + x,   9.82019  * sf + y);  //  22
+                glVertex2f( -10.696425  * sf + x,   8.08395  * sf + y);  //  23
+                glVertex2f( -8.843065  * sf + x,   6.66726  * sf + y);  //  24
+                glVertex2f( -8.995775  * sf + x,   8.71136  * sf + y);  //  25
             glEnd();
 
             glBegin(GL_POLYGON);
-                glVertex2f( 10  + x,   14  + y);  //  26
-                glVertex2f( 14  + x,   14 + y);  //  27
-                glVertex2f( 14 + x,    10  + y);  //  28
-                glVertex2f( 10  + x,   10  + y);  //  29
-                glVertex2f( 10  + x,   14  + y);  //  30
+                glVertex2f( 10  * sf + x,   14  * sf + y);  //  26
+                glVertex2f( 14  * sf + x,   14 * sf + y);  //  27
+                glVertex2f( 14 * sf + x,    10  * sf + y);  //  28
+                glVertex2f( 10  * sf + x,   10  * sf + y);  //  29
+                glVertex2f( 10  * sf + x,   14  * sf + y);  //  30
             glEnd();
 
             glBegin(GL_POLYGON);
-                glVertex2f( 10 + x,    4  + y);  //  31
-                glVertex2f( 14  + x,   4  + y);  //  32
-                glVertex2f( 14  + x,   0  + y);  //  33
-                glVertex2f( 10 + x,    0  + y);  //  34
-                glVertex2f( 10 + x,    4  + y);  //  35
+                glVertex2f( 10 * sf + x,    4  * sf + y);  //  31
+                glVertex2f( 14  * sf + x,   4  * sf + y);  //  32
+                glVertex2f( 14  * sf + x,   0  * sf + y);  //  33
+                glVertex2f( 10 * sf + x,    0  * sf + y);  //  34
+                glVertex2f( 10 * sf + x,    4  * sf + y);  //  35
            glEnd();
 
           break;
@@ -649,18 +658,18 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
 
             drColor(color);
             glBegin(GL_POLYGON);
-                glVertex2f(-7.0 + x,  2.0 + y); // 1
-                glVertex2f(-5.0 + x,  4.0 + y); // 2
-                glVertex2f(-1.0 + x,  6.0 + y); // 3
-                glVertex2f( 4.0 + x,  6.0 + y); // 4
-                glVertex2f( 7.0 + x,  4.0 + y); // 5
-                glVertex2f( 7.0 + x,  1.0 + y); // 6
-                glVertex2f( 6.0 + x, -2.0 + y); // 7
-                glVertex2f( 4.0 + x, -4.0 + y); // 8
-                glVertex2f( 0.0 + x, -6.0 + y); // 9
-                glVertex2f(-4.0 + x, -6.0 + y); // 10
-                glVertex2f(-8.0 + x, -3.0 + y); // 11
-                glVertex2f(-8.0 + x, -0.0 + y); // 12
+                glVertex2f(-7.0 * sf + x,  2.0 * sf + y); // 1
+                glVertex2f(-5.0 * sf + x,  4.0 * sf + y); // 2
+                glVertex2f(-1.0 * sf + x,  6.0 * sf + y); // 3
+                glVertex2f( 4.0 * sf + x,  6.0 * sf + y); // 4
+                glVertex2f( 7.0 * sf + x,  4.0 * sf + y); // 5
+                glVertex2f( 7.0 * sf + x,  1.0 * sf + y); // 6
+                glVertex2f( 6.0 * sf + x, -2.0 * sf + y); // 7
+                glVertex2f( 4.0 * sf + x, -4.0 * sf + y); // 8
+                glVertex2f( 0.0 * sf + x, -6.0 * sf + y); // 9
+                glVertex2f(-4.0 * sf + x, -6.0 * sf + y); // 10
+                glVertex2f(-8.0 * sf + x, -3.0 * sf + y); // 11
+                glVertex2f(-8.0 * sf + x, -0.0 * sf + y); // 12
             glEnd();
 
             /*
@@ -669,7 +678,7 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
             drColor(CColor(0.3, 0.4, 0.4));
             glBegin(GL_LINE_STRIP);
                 glVertex2f(x,  y);
-                glVertex2f(x + CMidiFile::ppqnAdjust(symbol.getMidiDuration()) * HORIZONTAL_SPACING_FACTOR, y);
+                glVertex2f(x + CMidiFile::ppqnAdjust(symbol.getMidiDuration()) * HORIZONTAL_SPACING_FACTOR * sf, y);
             glEnd();
             drColor(color);
             */
@@ -683,10 +692,10 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
             drColor(color);
             glLineWidth (3.0);
             glBegin(GL_LINES);
-                glVertex2f( 5.0 + x,-5.0 + y);
-                glVertex2f(-5.0 + x, 5.0 + y);
-                glVertex2f(-5.0 + x,-5.0 + y);
-                glVertex2f( 5.0 + x, 5.0 + y);
+                glVertex2f( 5.0 * sf + x,-5.0 * sf + y);
+                glVertex2f(-5.0 * sf + x, 5.0 * sf + y);
+                glVertex2f(-5.0 * sf + x,-5.0 * sf + y);
+                glVertex2f( 5.0 * sf + x, 5.0 * sf + y);
             glEnd();
             checkAccidental(symbol, x, y);
             break;
@@ -694,53 +703,53 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
         case PB_SYMBOL_sharp:
             glLineWidth (2.0);
             glBegin(GL_LINES);
-                glVertex2f(-2.0 + x, -14.0 + y);
-                glVertex2f(-2.0 + x,  14.0 + y);
+                glVertex2f(-2.0 * sf + x, -14.0 * sf + y);
+                glVertex2f(-2.0 * sf + x,  14.0 * sf + y);
 
-                glVertex2f( 2.0 + x, -13.0 + y);
-                glVertex2f( 2.0 + x,  15.0 + y);
+                glVertex2f( 2.0 * sf + x, -13.0 * sf + y);
+                glVertex2f( 2.0 * sf + x,  15.0 * sf + y);
 
-                glVertex2f(-5.0 + x,   4.0 + y);
-                glVertex2f( 5.0 + x,   7.0 + y);
+                glVertex2f(-5.0 * sf + x,   4.0 * sf + y);
+                glVertex2f( 5.0 * sf + x,   7.0 * sf + y);
 
-                glVertex2f(-5.0 + x,  -6.0 + y);
-                glVertex2f( 5.0 + x,  -3.0 + y);
+                glVertex2f(-5.0 * sf + x,  -6.0 * sf + y);
+                glVertex2f( 5.0 * sf + x,  -3.0 * sf + y);
             glEnd();
             break;
 
          case PB_SYMBOL_flat:
             glLineWidth (2.0);
             glBegin(GL_LINE_STRIP);
-                glVertex2f(-4.0 + x, 17.0 + y);  // 1
-                glVertex2f(-4.0 + x, -6.0 + y);  // 2
-                glVertex2f( 2.0 + x, -2.0 + y);  // 3
-                glVertex2f( 5.0 + x,  2.0 + y);  // 4
-                glVertex2f( 5.0 + x,  4.0 + y);  // 5
-                glVertex2f( 3.0 + x,  5.0 + y);  // 6
-                glVertex2f( 0.0 + x,  5.0 + y);  // 7
-                glVertex2f(-4.0 + x,  2.0 + y);  // 8
+                glVertex2f(-4.0 * sf + x, 17.0 * sf + y);  // 1
+                glVertex2f(-4.0 * sf + x, -6.0 * sf + y);  // 2
+                glVertex2f( 2.0 * sf + x, -2.0 * sf + y);  // 3
+                glVertex2f( 5.0 * sf + x,  2.0 * sf + y);  // 4
+                glVertex2f( 5.0 * sf + x,  4.0 * sf + y);  // 5
+                glVertex2f( 3.0 * sf + x,  5.0 * sf + y);  // 6
+                glVertex2f( 0.0 * sf + x,  5.0 * sf + y);  // 7
+                glVertex2f(-4.0 * sf + x,  2.0 * sf + y);  // 8
             glEnd();
             break;
 
          case PB_SYMBOL_natural:
             glLineWidth (2.0);
             glBegin(GL_LINES);
-                glVertex2f(  3 + x,   -15  + y);  //  1
-                glVertex2f(  3 + x,   8  + y);  //  2
+                glVertex2f(  3 * sf + x,   -15  * sf + y);  //  1
+                glVertex2f(  3 * sf + x,   8  * sf + y);  //  2
 
-                glVertex2f( -3 + x,   -8  + y);  //  3
-                glVertex2f( -3 + x,   15  + y);  //  4
+                glVertex2f( -3 * sf + x,   -8  * sf + y);  //  3
+                glVertex2f( -3 * sf + x,   15  * sf + y);  //  4
 
-                glVertex2f(  3 + x,   8  + y);  //  5
-                glVertex2f( -3 + x,   2  + y);  //  6
+                glVertex2f(  3 * sf + x,   8  * sf + y);  //  5
+                glVertex2f( -3 * sf + x,   2  * sf + y);  //  6
 
-                glVertex2f(  3 + x,   -2  + y);  //  7
-                glVertex2f( -3 + x,   -8  + y);  //  8
+                glVertex2f(  3 * sf + x,   -2  * sf + y);  //  7
+                glVertex2f( -3 * sf + x,   -8  * sf + y);  //  8
             glEnd();
             break;
 
         case PB_SYMBOL_barLine:
-            x += BEAT_MARKER_OFFSET * HORIZONTAL_SPACING_FACTOR; // the beat markers where entered early so now move them correctly
+            x += BEAT_MARKER_OFFSET * HORIZONTAL_SPACING_FACTOR * sf; // the beat markers where entered early so now move them correctly
             glLineWidth (4.0);
             drColor ((m_displayHand == PB_PART_left) ? Cfg::staveColorDim() : Cfg::staveColor());
             oneLine(x, CStavePos(PB_PART_right, 4).getPosYRelative(), x, CStavePos(PB_PART_right, -4).getPosYRelative());
@@ -749,7 +758,7 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
             break;
 
         case PB_SYMBOL_barMarker:
-            x += BEAT_MARKER_OFFSET * HORIZONTAL_SPACING_FACTOR; // the beat markers where entered early so now move them correctly
+            x += BEAT_MARKER_OFFSET * HORIZONTAL_SPACING_FACTOR * sf; // the beat markers where entered early so now move them correctly
             glLineWidth (5.0);
             drColor(Cfg::barMarkerColor());
             oneLine(x, CStavePos(PB_PART_right, m_beatMarkerHeight).getPosYRelative(), x, CStavePos(PB_PART_left, -m_beatMarkerHeight).getPosYRelative());
@@ -757,7 +766,7 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
             break;
 
         case PB_SYMBOL_beatMarker:
-            x += BEAT_MARKER_OFFSET * HORIZONTAL_SPACING_FACTOR; // the beat markers where entered early so now move them correctly
+            x += BEAT_MARKER_OFFSET * HORIZONTAL_SPACING_FACTOR * sf; // the beat markers where entered early so now move them correctly
             glLineWidth (4.0);
             drColor(Cfg::beatMarkerColor());
             oneLine(x, CStavePos(PB_PART_right, m_beatMarkerHeight).getPosYRelative(), x, CStavePos(PB_PART_left, -m_beatMarkerHeight).getPosYRelative());
@@ -768,8 +777,9 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
             {
                 float topY = CStavePos(PB_PART_right, m_beatMarkerHeight).getPosY();
                 float bottomY = CStavePos(PB_PART_left, -m_beatMarkerHeight).getPosY();
-                float early = Cfg::playZoneEarly() * HORIZONTAL_SPACING_FACTOR;
-                float late = Cfg::playZoneLate() * HORIZONTAL_SPACING_FACTOR;
+                float early = Cfg::playZoneEarly() * HORIZONTAL_SPACING_FACTOR * sf;
+
+                float late = Cfg::playZoneLate() * HORIZONTAL_SPACING_FACTOR * sf;
                 //glColor3f (0.7, 1.0, 0.7);
                 glColor3f (0.0, 0.0, 0.3);
                 glRectf(x-late, topY, x + early, bottomY);
@@ -797,7 +807,7 @@ void CDraw::drawSymbol(CSymbol symbol, float x, float y, CSlot* slot)
         float pianistX = symbol.getPianistTiming();
         if ( pianistX != NOT_USED)
         {
-            pianistX =  x + pianistX * HORIZONTAL_SPACING_FACTOR;
+            pianistX =  x + pianistX * HORIZONTAL_SPACING_FACTOR * sf;
             drColor(CColor(1.0, 1.0, 1.0));
             glLineWidth (2.0);
             glBegin(GL_LINES);

--- a/src/Draw.h
+++ b/src/Draw.h
@@ -93,6 +93,10 @@ public:
     void drawSymbol(CSymbol symbol, float x);
     void drawSlot(CSlot* slot);
 
+#ifndef NO_USE_FTGL
+    virtual void refreshFontSize();
+#endif
+
     static void setDisplayHand(whichPart_t hand)
     {
         m_displayHand = hand;

--- a/src/GlView.h
+++ b/src/GlView.h
@@ -50,6 +50,7 @@ public:
     CSong* getSongObject() {return m_song;}
     CScore* getScoreObject() {return m_score;}
     int m_cfg_openGlOptimise;
+    void recalculateGeometry(int width, int height);
 
     void stopTimerEvent();
     void startTimerEvent();
@@ -59,6 +60,7 @@ protected:
     void mediaTimerEvent(int ticks);
 
     void initializeGL();
+    void refreshFontSize();
     void paintGL();
     void resizeGL(int width, int height);
     void mousePressEvent(QMouseEvent *event);

--- a/src/GuiPreferencesDialog.cpp
+++ b/src/GuiPreferencesDialog.cpp
@@ -149,8 +149,13 @@ void GuiPreferencesDialog::init(CSong* song, CSettings* settings, CGLView * glVi
     showTutorPagesCheck->setChecked(m_settings->isTutorPagesEnabled());
     followThroughErrorsCheck->setChecked(m_settings->isFollowThroughErrorsEnabled());
     showColoredNotesCheck->setChecked(m_settings->isColoredNotesEnabled());
+    scalingHorizontalSlider->setValue((int) (m_settings->scalingFactor() * 10.0));
 
     followStopPointCombo->setCurrentIndex(m_song->cfg_stopPointMode);
+
+    connect(scalingHorizontalSlider, SIGNAL(valueChanged(int)),
+        this, SLOT(updateScalingLabelCurrentValue()));
+    updateScalingLabelCurrentValue();
 
     initLanguageCombo();
 }
@@ -164,6 +169,7 @@ void GuiPreferencesDialog::accept()
     m_settings->setTutorPagesEnabled( showTutorPagesCheck->isChecked());
     m_settings->setFollowThroughErrorsEnabled( followThroughErrorsCheck->isChecked());
     m_settings->setColoredNotes( showColoredNotesCheck->isChecked());
+    m_settings->setScalingFactor( (float)scalingHorizontalSlider->value() / 10.0);
     m_song->cfg_stopPointMode = static_cast<stopPointMode_t> (followStopPointCombo->currentIndex());
     m_settings->setValue("Score/StopPointMode", m_song->cfg_stopPointMode );
 
@@ -172,4 +178,12 @@ void GuiPreferencesDialog::accept()
     m_song->refreshScroll();
 
     this->QDialog::accept();
+}
+
+void GuiPreferencesDialog::updateScalingLabelCurrentValue()
+{
+    int value = scalingHorizontalSlider->value();
+    QString str = QString("%1 %").arg(QString::number(value * 10));
+    scalingLabelCurrentValue->setText(str);
+
 }

--- a/src/GuiPreferencesDialog.h
+++ b/src/GuiPreferencesDialog.h
@@ -49,6 +49,7 @@ public:
 
 private slots:
     void accept();
+    void updateScalingLabelCurrentValue();
 
 private:
     void initLanguageCombo();

--- a/src/GuiPreferencesDialog.ui
+++ b/src/GuiPreferencesDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>411</width>
-    <height>419</height>
+    <width>433</width>
+    <height>504</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_4">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
@@ -31,10 +31,112 @@
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
        <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="1">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="4" column="1">
+         <spacer name="horizontalSpacer_5">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="3" column="0">
+         <widget class="QCheckBox" name="followThroughErrorsCheck">
+          <property name="text">
+           <string>Follow Through Errors</string>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="0">
          <widget class="QCheckBox" name="courtesyAccidentalsCheck">
           <property name="text">
            <string>Courtesy Accidentals</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="2" column="1">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="1">
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="showNoteNamesCheck">
+          <property name="text">
+           <string>Show Note Names</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="timingMarkersCheck">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Timing Markers</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QCheckBox" name="showColoredNotesCheck">
+          <property name="toolTip">
+           <string>Show color coded notes on the score</string>
+          </property>
+          <property name="text">
+           <string>Color Coded Notes</string>
           </property>
          </widget>
         </item>
@@ -58,107 +160,66 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <spacer name="horizontalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="0" column="1">
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="2" column="0">
-         <widget class="QCheckBox" name="timingMarkersCheck">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
+        <item row="6" column="0">
+         <widget class="QLabel" name="scalingLabel">
           <property name="text">
-           <string>Timing Markers</string>
+           <string>Scaling:</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QCheckBox" name="showNoteNamesCheck">
-          <property name="text">
-           <string>Show Note Names</string>
+        <item row="6" column="1">
+         <layout class="QHBoxLayout" name="scalingHorizontalLayout">
+          <property name="topMargin">
+           <number>5</number>
           </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+          <property name="bottomMargin">
+           <number>5</number>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="3" column="1">
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="3" column="0">
-         <widget class="QCheckBox" name="followThroughErrorsCheck">
-          <property name="text">
-           <string>Follow Through Errors</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QCheckBox" name="showColoredNotesCheck">
-          <property name="toolTip">
-           <string>Show color coded notes on the score</string>
-          </property>
-          <property name="text">
-           <string>Color Coded Notes</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
+          <item>
+           <widget class="QLabel" name="scalingLabelCurrentValue">
+            <property name="minimumSize">
+             <size>
+              <width>50</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSlider" name="scalingHorizontalSlider">
+            <property name="minimum">
+             <number>5</number>
+            </property>
+            <property name="maximum">
+             <number>25</number>
+            </property>
+            <property name="singleStep">
+             <number>1</number>
+            </property>
+            <property name="pageStep">
+             <number>1</number>
+            </property>
+            <property name="value">
+             <number>10</number>
+            </property>
+            <property name="sliderPosition">
+             <number>10</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="tickPosition">
+             <enum>QSlider::TicksAbove</enum>
+            </property>
+            <property name="tickInterval">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>

--- a/src/Piano.h
+++ b/src/Piano.h
@@ -47,7 +47,7 @@ typedef struct {
 } savedNoteOffChord_t;
 
 
-class CPiano : protected CDraw
+class CPiano : public CDraw
 {
 
 public:

--- a/src/QtWindow.cpp
+++ b/src/QtWindow.cpp
@@ -59,6 +59,7 @@ QtWindow::QtWindow()
     setWindowTitle(tr("Piano Booster"));
 
     Cfg::setDefaults();
+    Cfg::setScalingFactor(m_settings->scalingFactor());
 
     decodeCommandLine();
 
@@ -519,6 +520,12 @@ void QtWindow::setCurrentFile(const QString &fileName)
 
     updateRecentFileActions();
 
+}
+
+// Trigger recalculation of various spacings, positions, etc
+void QtWindow::refreshGlWidget()
+{
+    m_glWidget->recalculateGeometry(m_glWidget->width(), m_glWidget->height());
 }
 
 void QtWindow::website()

--- a/src/QtWindow.h
+++ b/src/QtWindow.h
@@ -75,6 +75,8 @@ public:
     void loadTutorHtml(const QString & name);
     void setCurrentFile(const QString &fileName);
 
+    void refreshGlWidget();
+
 private slots:
     void open();
     void help();

--- a/src/Score.cpp
+++ b/src/Score.cpp
@@ -116,11 +116,6 @@ void CScore::drawPianoKeyboard(){
         PianoKeyboard() {
             i = 0; k = 0;
             yStart = 0.0f;
-            xSize = Cfg::staveEndX() - Cfg::staveStartX();
-            ySize = 30;
-
-            xPlaceSize = xSize / 52.0f;
-            xKeySize = xPlaceSize - xPlaceSize * 0.1f;
             stopped = false;
         }
 
@@ -188,6 +183,12 @@ void CScore::drawPianoKeyboard(){
         }
 
         void drawKeyboard() {
+            // Recalculate here since scaling factor may have changed
+            xSize = Cfg::staveEndX() - Cfg::staveStartX();
+            ySize = 30 * Cfg::getScalingFactor();
+            xPlaceSize = xSize / 52.0f;
+            xKeySize = xPlaceSize - xPlaceSize * 0.1f;
+
             i = k = 0;
             drawWhiteKey();
             int b1 = i, k1 = k++;

--- a/src/Score.h
+++ b/src/Score.h
@@ -80,6 +80,12 @@ public:
             m_scroll[i]->reset();
     }
 
+    void recalculateGeometry()
+    {   size_t i;
+        for (i=0; i< arraySize(m_scroll); i++)
+            m_scroll[i]->recalculateGeometry();
+    }
+
     void drawScrollingSymbols(bool show = true)
     {   size_t i;
         for (i=0; i< arraySize(m_scroll); i++)
@@ -137,6 +143,18 @@ public:
     void drawScore();
     void drawScroll(bool refresh);
     void drawPianoKeyboard();
+
+#ifndef NO_USE_FTGL
+    void refreshFontSize() override
+    {
+        CDraw::refreshFontSize();
+        m_piano->refreshFontSize();
+
+        size_t i;
+        for (i=0; i< arraySize(m_scroll); i++)
+            m_scroll[i]->refreshFontSize();
+    }
+#endif
 
 protected:
     CPiano* m_piano;

--- a/src/Scroll.cpp
+++ b/src/Scroll.cpp
@@ -28,6 +28,7 @@
 
 #include "Cfg.h"
 #include "Scroll.h"
+#include "Settings.h"
 
 //#define NOTE_AHEAD_GAP          50
 //#define NOTE_BEHIND_GAP          14
@@ -383,6 +384,11 @@ void CScroll::reset()
     m_symbolID = 0;
 
     m_scrollQueue->clear();
+    recalculateGeometry();
+}
+
+void CScroll::recalculateGeometry()
+{
     m_ppqnFactor = static_cast<float>(DEFAULT_PPQN) / CMidiFile::getPulsesPerQuarterNote();
-    m_noteSpacingFactor = m_ppqnFactor * HORIZONTAL_SPACING_FACTOR;
+    m_noteSpacingFactor = m_ppqnFactor * HORIZONTAL_SPACING_FACTOR * m_settings->scalingFactor();
 }

--- a/src/Scroll.h
+++ b/src/Scroll.h
@@ -43,6 +43,7 @@ public:
     CScroll(int id, CSettings* settings) : CDraw(settings)
     {
         m_id = id;
+        m_settings = settings;
         m_symbolID = 0;
 
         m_notation = new CNotation();
@@ -63,6 +64,7 @@ public:
     void scrollDeltaTime(int ticks);
     void transpose(int transpose);
     void refresh();
+    void recalculateGeometry();
     void setPlayedNoteColor(int note, CColor color, int wantedDelta, int pianistTimming);
     void setChannel(int chan)
     {
@@ -98,6 +100,7 @@ private:
     int findWantedChord(int note, CColor color, int wantedDelta);
 
     int m_id;      // There are lots of these class running but each class has a unique id
+    CSettings *m_settings;
     CNotation *m_notation;
     int m_deltaHead;
     int m_deltaTail;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -48,6 +48,7 @@
 #include "GuiSidePanel.h"
 #include "QtWindow.h"
 #include "version.h"
+#include "Draw.h"
 
 #if WITH_INTERNAL_FLUIDSYNTH
 #include "MidiDeviceFluidSynth.h"
@@ -72,6 +73,7 @@ CSettings::CSettings(QtWindow *mainWindow) : QSettings(CSettings::IniFormat, CSe
     m_tutorPagesEnabled = value("Tutor/TutorPages", true ).toBool();
     CNotation::setCourtesyAccidentals(value("Score/CourtesyAccidentals", false ).toBool());
     m_followThroughErrorsEnabled = value("Score/FollowThroughErrors", false ).toBool();
+    m_scalingFactor = value("Score/ScalingFactor", 1.0).toFloat();
 
     // load Fluid settings
     setFluidSoundFontNames( value("FluidSynth/SoundFont").toStringList());
@@ -116,6 +118,12 @@ void CSettings::setCourtesyAccidentals(bool value) {
 void CSettings::setFollowThroughErrorsEnabled(bool value) {
     m_followThroughErrorsEnabled = value;
     setValue("Score/FollowThroughErrors", value );
+}
+
+void CSettings::setScalingFactor(float value) {
+    m_scalingFactor = value;
+    setValue("Score/ScalingFactor", value);
+    m_mainWindow->refreshGlWidget();
 }
 
 // Open a document if it exists or else create it (also delete an duplicates
@@ -404,7 +412,7 @@ void CSettings::loadSettings()
 
     updateWarningMessages();
     updateTutorPage();
-
+    setScalingFactor(m_scalingFactor);
 }
 
 void CSettings::unzipBoosterMusicBooks()

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -53,6 +53,7 @@ public:
 
     bool isTutorPagesEnabled() { return m_tutorPagesEnabled; }
     bool isFollowThroughErrorsEnabled() { return m_followThroughErrorsEnabled; }
+    float scalingFactor() { return m_scalingFactor; }
     bool isColoredNotesEnabled() { return m_coloredNotes; }
 
     /// Saves in the .ini file whether the user wants to show the note names
@@ -60,6 +61,7 @@ public:
     void setColoredNotes(bool value);
     void setTutorPagesEnabled(bool value);
     void setFollowThroughErrorsEnabled(bool value);
+    void setScalingFactor(float value);
 
     void setCourtesyAccidentals(bool value);
     void setAdvancedMode(bool value) { m_advancedMode = value;}
@@ -202,6 +204,7 @@ private:
     bool m_tutorPagesEnabled;
     bool m_advancedMode;
     bool m_followThroughErrorsEnabled;
+    float m_scalingFactor;
     QString m_bookPath;
     QString m_currentBookName;
     QString m_currentSongName;

--- a/src/StavePosition.cpp
+++ b/src/StavePosition.cpp
@@ -34,6 +34,7 @@ int CStavePos::m_KeySignature;
 int CStavePos::m_KeySignatureMajorMinor;
 const staveLookup_t*  CStavePos::m_staveLookUpTable;
 float CStavePos::m_staveCentralOffset = (staveHeight() * 3)/2;
+float CStavePos::m_scalingFactor = 1.0;
 
 ////////////////////////////////////////////////////////////////////////////////
 //! @brief Calculates the position of a note on the stave

--- a/src/StavePosition.h
+++ b/src/StavePosition.h
@@ -78,9 +78,9 @@ public:
         m_hand = hand;
         m_offsetY = getStaveCenterY();
         if (m_hand == PB_PART_right)
-            m_offsetY += staveCentralOffset();
+            m_offsetY += staveCentralOffset() * m_scalingFactor;
         else if (m_hand == PB_PART_left)
-            m_offsetY -= staveCentralOffset();
+            m_offsetY -= staveCentralOffset() * m_scalingFactor;
     }
 
     void notePos(whichPart_t hand, int midiNote);
@@ -109,18 +109,19 @@ public:
     int getStaveIndex() {return m_staveIndex;}
     whichPart_t getHand() {return m_hand;}
 
-    static float getVerticalNoteSpacing(){return verticalNoteSpacing();}
     static float getStaveCenterY(){return m_staveCenterY;}
     static void setStaveCenterY(float y) { m_staveCenterY = y; }
     static void setKeySignature(int key, int majorMinor);
     static int getKeySignature() {return m_KeySignature;}
     static void setStaveCentralOffset(float gap) { m_staveCentralOffset = gap; }
-    static float verticalNoteSpacing()      {return 7;}
-    static float staveHeight()              {return verticalNoteSpacing() * 8;}
+    static float verticalNoteSpacing() {return 7 * m_scalingFactor;}
+    static float staveHeight() {return verticalNoteSpacing() * 8;}
     static float staveCentralOffset()       {return m_staveCentralOffset;}
     // convert the midi note to the note name A B C D E F G
     static staveLookup_t midiNote2Name(int midiNote);
     static const staveLookup_t* getstaveLookupTable(int key);
+
+    static void setScalingFactor(float scalingFactor) { m_scalingFactor = scalingFactor; }
 
     // do we show a sharp or a flat for this key signature
     // returns 0 = none, 1=sharp, -1 =flat, 2=natural (# Key) , -2=natural (b Key)
@@ -153,6 +154,7 @@ private:
     static const staveLookup_t*  m_staveLookUpTable;
     static float m_staveCentralOffset;
     static float m_staveCenterY;
+    static float m_scalingFactor;
 };
 
 #endif //__STAVE_POS_H__


### PR DESCRIPTION
Hello everyone,

while using PB to learn playing the piano and reading musical notation, I had a hard time reading the notes on my laptop screen (1920x1080), especially with some distance to my eyes (midi keyboard in between). All workarounds seemed cumbersome. I looked around and noticed issue #199 where other people mentioned this as well. I really like PB a lot, but for me personally, this made it hard to learn smoothly and focus on what's important.

Having some coding experience, I decided to make a PR that implements scaling of the staves/notes and the keyboard widget. The scaling factor can be adjusted manually via the preferences dialog within a range of 50% to 250% of the original size, while 100% (original size) is still the default. I think this way graphics can be scaled to a good size for everyone's screen and needs. The scrolling area's max width gets adjusted accordingly. I do understand the concerns mentioned in #199 about flickering/tearing on older computers if the scrolling area is too large for them. With this approach, they will get the same size as before by default, while other people with more powerful hardware and larger screens are free to use larger sizes. On my mid-range laptop, scrolling worked smoothly even beyond 250%.

I did my best to integrate this feature cleanly into the codebase and follow code style conventions. The main challenge was to propagate the scaling factor everywhere it needs to be known (in a clean way) and trigger all necessary updates when it changes. I hope this PR will be considered useful, I'm looking forward to feedback, and I'm open to make corrections if needed.

![PianoBooster_scaling_demo](https://user-images.githubusercontent.com/63071667/165360120-f63de85c-9b5b-416d-9a06-78e8ae3cc433.png)
