### PR TITLE
Add the library paths of RtMidi

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,6 +148,7 @@ else()
         MESSAGE(FATAL_ERROR "rtmidi not found (Try building with option USE_BUNDLED_RTMIDI=ON)")
     endif(NOT RTMIDI_FOUND)
     include_directories(${RTMIDI_INCLUDE_DIRS})
+    link_directories(${RTMIDI_LIBRARY_DIRS})
 endif()
 
 # with SET() command you can change variables or define new ones


### PR DESCRIPTION
Fixes the build when pipewire is the provider of jack libraries.

It needs the library path obtained from pkgconfig dependencies of RtMidi.
This lib potentially resides in a path such as `/usr/lib64/pipewire-0.3/jack/libjack.so`.
