### PR TITLE
Captnfab/fix ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - "develop"
+      - "master"
 
 jobs:
   linux-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,8 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5)"
+          export PKG_CONFIG_PATH="$(brew --prefix readline)/lib/pkgconfig:$PKG_CONFIG_PATH"
+          cmake .. -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5);"
           make
           make install-translations
           $(brew --prefix qt@5)/bin/macdeployqt build/pianobooster.app -dmg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
              checksum.txt
 
   macos-build:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: Checkout
         uses: actions/checkout@v2.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,8 +60,6 @@ jobs:
         uses: actions/checkout@v2.0.0
       - name: Install dependencies
         run: |
-          brew update || brew update
-          brew upgrade
           brew install cmake qt5 ftgl pkg-config fluid-synth
       - name: Define variables
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v2.0.0
       - name: Install dependencies
         run: |
-          brew install cmake qt5 ftgl pkg-config fluid-synth
+          brew install cmake qt@5 ftgl pkg-config fluid-synth
       - name: Define variables
         run: |
           pb_ver=`grep PB_VERSION src/version.h | cut -d "\"" -f 2`
@@ -74,10 +74,10 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_PREFIX_PATH="$(brew --prefix qt)"
+          cmake .. -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5)"
           make
           make install-translations
-          $(brew --prefix qt)/bin/macdeployqt build/pianobooster.app -dmg
+          $(brew --prefix qt@5)/bin/macdeployqt build/pianobooster.app -dmg
           find .
           echo "Done!"
           mv build/*dmg ../${pb_app_name}.dmg

--- a/src/MidiDeviceFluidSynth.cpp
+++ b/src/MidiDeviceFluidSynth.cpp
@@ -30,7 +30,13 @@
 
 static fluid_settings_t* s_debug_fluid_settings;
 
-static void debug_settings_foreach_func (void *data, const char *name, int type)
+static void debug_settings_foreach_func (void *data,
+#if FLUIDSYNTH_VERSION_MAJOR >= 2
+    const char *name,
+#else
+    char *name,
+#endif
+    int type)
 {
     char buffer[300];
     fluid_settings_copystr(s_debug_fluid_settings, name, buffer, sizeof (buffer));


### PR DESCRIPTION
MacOS X build was broken
- bump macosx version
- update qt5 package name
- do not upgrade all brew
- help brew find readline

General
- add FluidSynth < 2 compatibility patch (thanks to @Martchus)
- do not double build on pull requests