### PR TITLE
Editable clefs

### DIFF
--- a/src/Draw.cpp
+++ b/src/Draw.cpp
@@ -825,19 +825,20 @@ void CDraw::drawSlot(CSlot* slot)
     //int av8Left = slot->getAv8Left();
     for (int i=0; i < slot->length(); i++)
     {
-    	whichPart_t hand = slot->getSymbol(i).getHand();
-    	int clef = PB_SYMBOL_gClef;
-    	if (hand == PB_PART_right) {
-    		clef = m_settings->value("SidePanel/clefRight").toInt();
-    	}
-    	else if (hand == PB_PART_left) {
-    		clef = m_settings->value("SidePanel/clefLeft").toInt();
-    	}
-        stavePos.notePos(hand, slot->getSymbol(i).getNote(), clef);
+        whichPart_t hand = slot->getSymbol(i).getHand();
+        int clef = PB_SYMBOL_gClef;
+        if (hand == PB_PART_right) {
+            clef = m_settings->value("SidePanel/clefRight").toInt();
+        }
+        else if (hand == PB_PART_left) {
+            clef = m_settings->value("SidePanel/clefLeft").toInt();
+        }
+        CSymbol symbol = slot->getSymbol(i);
+        symbol.setClef(clef);
+        stavePos.notePos(hand, symbol.getNote(), clef);
         //ppLogTrace ("compileSlot len %d id %2d next %2d time %2d type %2d note %2d", slot->length(), slot->m_displayListId,
         //slot->m_nextDisplayListId, slot->getDeltaTime(), slot->getSymbol(i).getType(), slot->getSymbol(i).getNote());
-
-        drawSymbol(slot->getSymbol(i), 0.0, stavePos.getPosYRelative()); // we add this  back when drawing this symbol
+        drawSymbol(symbol, 0.0, stavePos.getPosYRelative()); // we add this  back when drawing this symbol
     }
 }
 

--- a/src/Draw.cpp
+++ b/src/Draw.cpp
@@ -825,7 +825,15 @@ void CDraw::drawSlot(CSlot* slot)
     //int av8Left = slot->getAv8Left();
     for (int i=0; i < slot->length(); i++)
     {
-        stavePos.notePos(slot->getSymbol(i).getHand(), slot->getSymbol(i).getNote());
+    	whichPart_t hand = slot->getSymbol(i).getHand();
+    	int clef = PB_SYMBOL_gClef;
+    	if (hand == PB_PART_right) {
+    		clef = m_settings->value("SidePanel/clefRight").toInt();
+    	}
+    	else if (hand == PB_PART_left) {
+    		clef = m_settings->value("SidePanel/clefLeft").toInt();
+    	}
+        stavePos.notePos(hand, slot->getSymbol(i).getNote(), clef);
         //ppLogTrace ("compileSlot len %d id %2d next %2d time %2d type %2d note %2d", slot->length(), slot->m_displayListId,
         //slot->m_nextDisplayListId, slot->getDeltaTime(), slot->getSymbol(i).getType(), slot->getSymbol(i).getNote());
 

--- a/src/GuiSidePanel.cpp
+++ b/src/GuiSidePanel.cpp
@@ -82,7 +82,6 @@ void GuiSidePanel::init(CSong* songObj, CTrackList* trackList, GuiTopBar* topBar
 
     on_rhythmTappingCombo_activated(m_settings->value("SidePanel/rhythmTapping",0).toInt());
     rhythmTappingCombo->setCurrentIndex(m_song->cfg_rhythmTapping);
-
     repeatSong->setChecked(m_settings->value("SidePanel/repeatSong",false).toBool());
     connect(repeatSong,SIGNAL(stateChanged(int)),this,SLOT(on_repeatSong_released()));
 
@@ -105,6 +104,18 @@ void GuiSidePanel::init(CSong* songObj, CTrackList* trackList, GuiTopBar* topBar
     connect(act, SIGNAL(triggered()), this, SLOT(clearTrackPart()));
 
     trackListWidget->setContextMenuPolicy(Qt::ActionsContextMenu);
+
+    m_settings->setValue("SidePanel/clefRight",PB_SYMBOL_gClef);
+	m_settings->setValue("SidePanel/clefLeft",PB_SYMBOL_fClef);
+    clefRightCombo->addItem(tr("Treble"),PB_SYMBOL_gClef);
+    clefRightCombo->addItem(tr("Bass"),PB_SYMBOL_fClef);
+    clefLeftCombo->addItem(tr("Treble"),PB_SYMBOL_gClef);
+    clefLeftCombo->addItem(tr("Bass"),PB_SYMBOL_fClef);
+    clefRightCombo->setCurrentIndex(0);
+    clefLeftCombo->setCurrentIndex(1);
+    trackListWidget->addAction(act);
+    connect(clefRightCombo, SIGNAL(currentTextChanged(QString)), this, SLOT(on_clefRightComboChange(QString)));
+    connect(clefLeftCombo, SIGNAL(currentTextChanged(QString)), this, SLOT(on_clefLeftComboChange(QString)));
 }
 
 void GuiSidePanel::refresh() {
@@ -269,13 +280,17 @@ void GuiSidePanel::updateTranslate(){
 
     rhythmTappingCombo->setItemText(0,tr("Drums"));
     rhythmTappingCombo->setItemText(1,tr("Melody"));
+    clefRightCombo->setItemText(0,tr("Treble"));
+	clefRightCombo->setItemText(1,tr("Bass"));
+    clefLeftCombo->setItemText(0,tr("Treble"));
+	clefLeftCombo->setItemText(1,tr("Bass"));
 
     retranslateUi(this);
 
     // ---  smart resize panel  --- //
     int maxDeltaWidth=0;
     this->setMaximumWidth(300); // default
-    QVector<QWidget*> listCheckWidget {label2,listenRadio,rhythmTapRadio,followYouRadio,playAlongRadio,rightHandRadio,bothHandsRadio,leftHandRadio};
+    QVector<QWidget*> listCheckWidget {label2,listenRadio,rhythmTapRadio,followYouRadio,playAlongRadio,rightHandRadio,bothHandsRadio,leftHandRadio,clefRightCombo,clefLeftCombo};
 
     for (QWidget* w:listCheckWidget){
         int delta = 0;
@@ -313,3 +328,10 @@ void GuiSidePanel::on_rhythmTappingCombo_activated (int index)
     autoSetMuteYourPart();
 }
 
+void GuiSidePanel::on_clefComboChange (const QString &name, int value)
+{
+    m_settings->setValue(name,value);
+    m_song->refreshScroll();
+    //m_score->drawScore(); // TODO makes it crash
+    //TODO do I need to do more to request a redraw?
+}

--- a/src/GuiSidePanel.cpp
+++ b/src/GuiSidePanel.cpp
@@ -32,6 +32,7 @@
 #include "GuiTopBar.h"
 #include "TrackList.h"
 #include "Conductor.h"
+#include "Draw.h"
 
 GuiSidePanel::GuiSidePanel(QWidget *parent, CSettings* settings)
     : QWidget(parent), m_parent(parent)
@@ -106,7 +107,7 @@ void GuiSidePanel::init(CSong* songObj, CTrackList* trackList, GuiTopBar* topBar
     trackListWidget->setContextMenuPolicy(Qt::ActionsContextMenu);
 
     m_settings->setValue("SidePanel/clefRight",PB_SYMBOL_gClef);
-	m_settings->setValue("SidePanel/clefLeft",PB_SYMBOL_fClef);
+    m_settings->setValue("SidePanel/clefLeft",PB_SYMBOL_fClef);
     clefRightCombo->addItem(tr("Treble"),PB_SYMBOL_gClef);
     clefRightCombo->addItem(tr("Bass"),PB_SYMBOL_fClef);
     clefLeftCombo->addItem(tr("Treble"),PB_SYMBOL_gClef);
@@ -281,9 +282,9 @@ void GuiSidePanel::updateTranslate(){
     rhythmTappingCombo->setItemText(0,tr("Drums"));
     rhythmTappingCombo->setItemText(1,tr("Melody"));
     clefRightCombo->setItemText(0,tr("Treble"));
-	clefRightCombo->setItemText(1,tr("Bass"));
+    clefRightCombo->setItemText(1,tr("Bass"));
     clefLeftCombo->setItemText(0,tr("Treble"));
-	clefLeftCombo->setItemText(1,tr("Bass"));
+    clefLeftCombo->setItemText(1,tr("Bass"));
 
     retranslateUi(this);
 
@@ -331,7 +332,6 @@ void GuiSidePanel::on_rhythmTappingCombo_activated (int index)
 void GuiSidePanel::on_clefComboChange (const QString &name, int value)
 {
     m_settings->setValue(name,value);
+    CDraw::forceCompileRedraw();
     m_song->refreshScroll();
-    //m_score->drawScore(); // TODO makes it crash
-    //TODO do I need to do more to request a redraw?
 }

--- a/src/GuiSidePanel.h
+++ b/src/GuiSidePanel.h
@@ -145,6 +145,25 @@ private slots:
 
     void on_rhythmTappingCombo_activated (int index);
 
+    void on_clefComboChange (const QString &name, int value);
+    void on_clefComboChange (const QString &name, const QString &text)
+    {
+    	int value = -1;
+    	if (text.toLower() == "treble")
+    		value = PB_SYMBOL_gClef;
+    	else if (text.toLower() == "bass")
+    		value = PB_SYMBOL_fClef;
+    	on_clefComboChange(name, value);
+    }
+    void on_clefRightComboChange (const QString &text)
+    {
+    	on_clefComboChange("SidePanel/clefRight", text);
+    }
+    void on_clefLeftComboChange (const QString &text)
+    {
+    	on_clefComboChange("SidePanel/clefLeft", text);
+    }
+
     void on_muteYourPartCheck_toggled (bool checked)
     {
         if (m_song) m_song->mutePianistPart(checked);

--- a/src/GuiSidePanel.h
+++ b/src/GuiSidePanel.h
@@ -148,20 +148,20 @@ private slots:
     void on_clefComboChange (const QString &name, int value);
     void on_clefComboChange (const QString &name, const QString &text)
     {
-    	int value = -1;
-    	if (text.toLower() == "treble")
-    		value = PB_SYMBOL_gClef;
-    	else if (text.toLower() == "bass")
-    		value = PB_SYMBOL_fClef;
-    	on_clefComboChange(name, value);
+        int value = -1;
+        if (text.toLower() == "treble")
+            value = PB_SYMBOL_gClef;
+        else if (text.toLower() == "bass")
+            value = PB_SYMBOL_fClef;
+        on_clefComboChange(name, value);
     }
     void on_clefRightComboChange (const QString &text)
     {
-    	on_clefComboChange("SidePanel/clefRight", text);
+        on_clefComboChange("SidePanel/clefRight", text);
     }
     void on_clefLeftComboChange (const QString &text)
     {
-    	on_clefComboChange("SidePanel/clefLeft", text);
+        on_clefComboChange("SidePanel/clefLeft", text);
     }
 
     void on_muteYourPartCheck_toggled (bool checked)

--- a/src/GuiSidePanel.ui
+++ b/src/GuiSidePanel.ui
@@ -286,6 +286,34 @@
     </widget>
    </item>
    <item>
+    <layout class="QHBoxLayout">
+     <item>
+      <widget class="QLabel" name="label3">
+       <property name="text">
+        <string>Right Hand Clef:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="clefRightCombo"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout">
+     <item>
+      <widget class="QLabel" name="label4">
+       <property name="text">
+        <string>Left Hand Clef:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="clefLeftCombo"/>
+     </item>
+    </layout>
+   </item>
+   <item>
     <spacer>
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/Score.cpp
+++ b/src/Score.cpp
@@ -230,8 +230,14 @@ void CScore::drawScore()
         glNewList (m_scoreDisplayListId, GL_COMPILE_AND_EXECUTE);
             drColor (Cfg::staveColor());
 
-            drawSymbol(CSymbol(PB_SYMBOL_gClef, CStavePos(PB_PART_right, -1)), Cfg::clefX()); // The Treble Clef
-            drawSymbol(CSymbol(PB_SYMBOL_fClef, CStavePos(PB_PART_left, 1)), Cfg::clefX());
+            if (m_settings->value("SidePanel/clefRight").toInt() == PB_SYMBOL_gClef)
+            	drawSymbol(CSymbol(PB_SYMBOL_gClef, CStavePos(PB_PART_right, -1)), Cfg::clefX()); // The Treble Clef
+            else if (m_settings->value("SidePanel/clefRight").toInt() == PB_SYMBOL_fClef)
+            	drawSymbol(CSymbol(PB_SYMBOL_fClef, CStavePos(PB_PART_right, -1)), Cfg::clefX());
+            if (m_settings->value("SidePanel/clefLeft").toInt() == PB_SYMBOL_gClef)
+            	drawSymbol(CSymbol(PB_SYMBOL_gClef, CStavePos(PB_PART_left, 1)), Cfg::clefX());
+            else if (m_settings->value("SidePanel/clefLeft").toInt() == PB_SYMBOL_fClef)
+            	drawSymbol(CSymbol(PB_SYMBOL_fClef, CStavePos(PB_PART_left, 1)), Cfg::clefX());
             drawKeySignature(CStavePos::getKeySignature());
             drawStaves(Cfg::staveStartX(), Cfg::scrollStartX());
         glEndList ();

--- a/src/Score.cpp
+++ b/src/Score.cpp
@@ -231,13 +231,13 @@ void CScore::drawScore()
             drColor (Cfg::staveColor());
 
             if (m_settings->value("SidePanel/clefRight").toInt() == PB_SYMBOL_gClef)
-            	drawSymbol(CSymbol(PB_SYMBOL_gClef, CStavePos(PB_PART_right, -1)), Cfg::clefX()); // The Treble Clef
+                drawSymbol(CSymbol(PB_SYMBOL_gClef, CStavePos(PB_PART_right, -1)), Cfg::clefX()); // The Treble Clef
             else if (m_settings->value("SidePanel/clefRight").toInt() == PB_SYMBOL_fClef)
-            	drawSymbol(CSymbol(PB_SYMBOL_fClef, CStavePos(PB_PART_right, -1)), Cfg::clefX());
+                drawSymbol(CSymbol(PB_SYMBOL_fClef, CStavePos(PB_PART_right, 1)), Cfg::clefX());
             if (m_settings->value("SidePanel/clefLeft").toInt() == PB_SYMBOL_gClef)
-            	drawSymbol(CSymbol(PB_SYMBOL_gClef, CStavePos(PB_PART_left, 1)), Cfg::clefX());
+                drawSymbol(CSymbol(PB_SYMBOL_gClef, CStavePos(PB_PART_left, -1)), Cfg::clefX());
             else if (m_settings->value("SidePanel/clefLeft").toInt() == PB_SYMBOL_fClef)
-            	drawSymbol(CSymbol(PB_SYMBOL_fClef, CStavePos(PB_PART_left, 1)), Cfg::clefX());
+                drawSymbol(CSymbol(PB_SYMBOL_fClef, CStavePos(PB_PART_left, 1)), Cfg::clefX());
             drawKeySignature(CStavePos::getKeySignature());
             drawStaves(Cfg::staveStartX(), Cfg::scrollStartX());
         glEndList ();

--- a/src/StavePosition.cpp
+++ b/src/StavePosition.cpp
@@ -37,7 +37,7 @@ float CStavePos::m_staveCentralOffset = (staveHeight() * 3)/2;
 
 ////////////////////////////////////////////////////////////////////////////////
 //! @brief Calculates the position of a note on the stave
-void CStavePos::notePos(whichPart_t hand, int midiNote)
+void CStavePos::notePos(whichPart_t hand, int midiNote, int clef) // in fact clef is of type musicalSymbol_t but causes circular reference
 {
     const int notesInAnOctive = 7; // Don't count middle C twice
     const int semitonesInAnOctive = 12;
@@ -48,13 +48,21 @@ void CStavePos::notePos(whichPart_t hand, int midiNote)
 
     lookUpItem = &m_staveLookUpTable[index];
 
-    if (m_hand == PB_PART_right)
+    if (clef == -1) {
+    	if (m_hand == PB_PART_right)
+    		clef = PB_SYMBOL_gClef;
+		if (m_hand == PB_PART_left)
+			clef = PB_SYMBOL_fClef;
+    }
+    if (m_hand == PB_PART_right && clef == PB_SYMBOL_gClef || m_hand == PB_PART_left && clef == PB_SYMBOL_gClef)
         m_staveIndex =   lookUpItem->pianoNote - 7;
-    else if (m_hand == PB_PART_left)
+    else if (m_hand == PB_PART_left && clef == PB_SYMBOL_fClef || m_hand == PB_PART_right && clef == PB_SYMBOL_fClef)
         m_staveIndex = lookUpItem->pianoNote + 5;
 
     m_staveIndex += (midiNote/semitonesInAnOctive)*notesInAnOctive - notesInAnOctive*5 ;
     m_accidental = lookUpItem->accidental;
+    ppLogInfo("chan %d clef %2d Note %2d - %2d (%d %d %d),\n", midiNote, clef, m_staveIndex, m_accidental,
+            index%semitonesInAnOctive, lookUpItem->pianoNote, (midiNote/semitonesInAnOctive)*notesInAnOctive);
     //ppLogTrace("chan %d Note %2d - %2d (%d %d %d),\n", midiNote, m_staveIndex, m_accidental,
         //index%semitonesInAnOctive, lookUpItem->pianoNote, (midiNote/semitonesInAnOctive)*notesInAnOctive);
 }

--- a/src/StavePosition.cpp
+++ b/src/StavePosition.cpp
@@ -49,20 +49,18 @@ void CStavePos::notePos(whichPart_t hand, int midiNote, int clef) // in fact cle
     lookUpItem = &m_staveLookUpTable[index];
 
     if (clef == -1) {
-    	if (m_hand == PB_PART_right)
-    		clef = PB_SYMBOL_gClef;
-		if (m_hand == PB_PART_left)
-			clef = PB_SYMBOL_fClef;
+        if (m_hand == PB_PART_right)
+            clef = PB_SYMBOL_gClef;
+        if (m_hand == PB_PART_left)
+            clef = PB_SYMBOL_fClef;
     }
     if (m_hand == PB_PART_right && clef == PB_SYMBOL_gClef || m_hand == PB_PART_left && clef == PB_SYMBOL_gClef)
-        m_staveIndex =   lookUpItem->pianoNote - 7;
+        m_staveIndex = lookUpItem->pianoNote - 7;
     else if (m_hand == PB_PART_left && clef == PB_SYMBOL_fClef || m_hand == PB_PART_right && clef == PB_SYMBOL_fClef)
         m_staveIndex = lookUpItem->pianoNote + 5;
 
     m_staveIndex += (midiNote/semitonesInAnOctive)*notesInAnOctive - notesInAnOctive*5 ;
     m_accidental = lookUpItem->accidental;
-    ppLogInfo("chan %d clef %2d Note %2d - %2d (%d %d %d),\n", midiNote, clef, m_staveIndex, m_accidental,
-            index%semitonesInAnOctive, lookUpItem->pianoNote, (midiNote/semitonesInAnOctive)*notesInAnOctive);
     //ppLogTrace("chan %d Note %2d - %2d (%d %d %d),\n", midiNote, m_staveIndex, m_accidental,
         //index%semitonesInAnOctive, lookUpItem->pianoNote, (midiNote/semitonesInAnOctive)*notesInAnOctive);
 }

--- a/src/StavePosition.h
+++ b/src/StavePosition.h
@@ -83,7 +83,7 @@ public:
             m_offsetY -= staveCentralOffset();
     }
 
-    void notePos(whichPart_t hand, int midiNote);
+    void notePos(whichPart_t hand, int midiNote, int clef = -1); // in fact clef is of type musicalSymbol_t but causes circular reference
 
     ////////////////////////////////////////////////////////////////////////////////
     //! @brief Sets which stave the note will appear on

--- a/src/Symbol.h
+++ b/src/Symbol.h
@@ -73,14 +73,14 @@ public:
 
     ////////////////////////////////////////////////////////////////////////////////
     //@brief constructors
-    CSymbol(musicalSymbol_t type, whichPart_t hand, int midiNote)
+    CSymbol(musicalSymbol_t type, whichPart_t hand, int midiNote, int clef = -1)
     {
         init();
         m_symbolType = type;
         m_midiNote = midiNote;
         m_hand = hand;
         m_midiDuration = 0;
-        m_stavePos.notePos(hand, midiNote);
+        m_stavePos.notePos(hand, midiNote, clef);
     }
 
     CSymbol()
@@ -157,6 +157,11 @@ public:
 
     void setAccidentalModifer(accidentalModifer_t value) {m_accidentalModifer = value;}
     accidentalModifer_t getAccidentalModifer() {return m_accidentalModifer;}
+
+    void setClef(int clef = -1)
+    {
+        m_stavePos.notePos(m_hand, m_midiNote, clef);
+    }
 
 private:
     void init()


### PR DESCRIPTION
I implemented editable clefs by having two dropdown boxes where you can set the clefs used per hand (default: right-treble, left-bass). It dynamically updates using the default redrawing mechanism, redraws the clefs and moves the notes and all other symbol elements (accidentals etc). This solves issue #52 