### PR TITLE
Fix transparent, flickering staff area on Wayland

### DIFF
--- a/src/GlView.cpp
+++ b/src/GlView.cpp
@@ -326,7 +326,10 @@ void CGLView::mouseMoveEvent(QMouseEvent *event)
 void CGLView::initializeGL()
 {
     CColor color = Cfg::backgroundColor();
-    glClearColor (color.red, color.green, color.blue, 0.0);
+    // Alpha must be 1.0 (opaque): on Wayland the compositor honours the
+    // framebuffer alpha, so a 0.0 alpha makes the staff area see-through to
+    // the desktop and blurs/stutters as it scrolls. (Harmless on X11.)
+    glClearColor (color.red, color.green, color.blue, 1.0);
     glPixelStorei (GL_UNPACK_ALIGNMENT, 1);
     glShadeModel (GL_FLAT);
     //glEnable(GL_TEXTURE_2D);                        // Enable Texture Mapping


### PR DESCRIPTION
## Problem

On Wayland the OpenGL staff area renders **transparent** — the desktop shows through it, and the notes blur/smear as they scroll. On X11 it renders correctly, so this only affects Wayland sessions (now the default on Ubuntu, Fedora, etc.).

## Cause

`CGLView::initializeGL()` clears the framebuffer with an alpha of `0.0`:

```cpp
glClearColor (color.red, color.green, color.blue, 0.0);
```

X11 compositors treat the GL surface as opaque, so this was harmless. Wayland compositors honour the framebuffer alpha, so the cleared background becomes see-through and every scroll re-blends it against whatever is behind the window.

## Fix

Clear with alpha `1.0` so the surface is opaque (one line in `src/GlView.cpp`).

## Testing

Built with Qt6 on Ubuntu 24.04 (GNOME Wayland, native `qtwayland`). Before: staff shows the desktop behind it and smears while scrolling. After: solid background, clean scrolling. No behaviour change on X11.
