### PR TITLE
Default FluidSynth sample rate to 48 kHz

### DIFF
--- a/src/GuiMidiSetupDialog.cpp
+++ b/src/GuiMidiSetupDialog.cpp
@@ -70,6 +70,7 @@ void GuiMidiSetupDialog::init(CSong* song, CSettings* settings)
 
     sampleRateCombo->addItems({"22050", "44100","48000", "88200","96000"});
     sampleRateCombo->setValidator(new QIntValidator(22050, 96000, this));
+    sampleRateCombo->setCurrentIndex(2);   // 48000 Hz
     bufferSizeCombo->addItems({"64", "128", "512", "1024", "2024", "4096","8192"});
     bufferSizeCombo->setValidator(new QIntValidator(64, 8192, this));
     bufferSizeCombo->setCurrentIndex(1);
@@ -94,7 +95,7 @@ void GuiMidiSetupDialog::init(CSong* song, CSettings* settings)
         reverbCheck->setChecked(m_settings->value("FluidSynth/reverbCheck","false").toBool());
         chorusCheck->setChecked(m_settings->value("FluidSynth/chorusCheck","false").toBool());
         setComboFromSetting(audioDriverCombo, "FluidSynth/audioDriverCombo","pulseaudio");
-        setComboFromSetting(sampleRateCombo, "FluidSynth/sampleRateCombo","22050");
+        setComboFromSetting(sampleRateCombo, "FluidSynth/sampleRateCombo","48000");
         setComboFromSetting(bufferSizeCombo, "FluidSynth/bufferSizeCombo","128");
         setComboFromSetting(bufferCountCombo, "FluidSynth/bufferCountCombo","4");
      }

--- a/src/MidiDeviceFluidSynth.cpp
+++ b/src/MidiDeviceFluidSynth.cpp
@@ -100,8 +100,10 @@ bool CMidiDeviceFluidSynth::openMidiPort(midiType_t type, const QString &portNam
     // Create the settings.
     m_fluidSettings = new_fluid_settings();
 
-    // Change the settings if necessary
-    fluid_settings_setnum(m_fluidSettings, "synth.sample-rate", qsettings->value("FluidSynth/sampleRateCombo",22050).toInt());
+    // Change the settings if necessary.
+    // Default to 48 kHz to match modern audio stacks (PipeWire/PulseAudio run at
+    // 48 kHz), which avoids a resampling step.
+    fluid_settings_setnum(m_fluidSettings, "synth.sample-rate", qsettings->value("FluidSynth/sampleRateCombo",48000).toInt());
     fluid_settings_setint(m_fluidSettings, "audio.period-size", qsettings->value("FluidSynth/bufferSizeCombo", 128).toInt());
     fluid_settings_setint(m_fluidSettings, "audio.periods", qsettings->value("FluidSynth/bufferCountCombo", 4).toInt());
 


### PR DESCRIPTION
## Problem

The internal FluidSynth synthesizer defaults to a **22050 Hz** sample rate. Modern audio stacks (PipeWire and PulseAudio) run at 48 kHz, so the old default forces an extra resampling step that adds audible latency between a note crossing the bar and being heard.

## Fix

Default the sample rate to **48000 Hz** to match the typical system rate and avoid the resample. The rate remains fully user-configurable in the MIDI setup dialog; the combo box now also defaults its selection to 48000.

Changed in `src/MidiDeviceFluidSynth.cpp` (the runtime default) and `src/GuiMidiSetupDialog.cpp` (the dialog default).

## Testing

Built with Qt6 on Ubuntu 24.04 / PipeWire. Latency between keypress/score and sound is noticeably tighter, and `synth.sample-rate` now matches the device rate (no resampling).
