### PR TITLE
Don't reject valid time signatures as corrupted

### DIFF
--- a/src/MidiTrack.cpp
+++ b/src/MidiTrack.cpp
@@ -200,13 +200,12 @@ void CMidiTrack::readTimeSignatureEvent()
         return;
     }
     timeSigNumerator = readByte();  // The number on the top
-    timeSigDenominator = readByte(); // the number on the bottom
-    if (timeSigDenominator >= 5)
-    {
-        errorFail(SMF_CORRUPTED_MIDI_FILE);
-        return;
-    }
-    if (timeSigNumerator > 20)
+    timeSigDenominator = readByte(); // the number on the bottom (a power of two, stored as the exponent)
+    // The denominator is the exponent of a power of two: 0..7 covers 1/1 .. 1/128,
+    // which spans every time signature found in real music (the previous limit of
+    // 5 wrongly rejected valid 1/32 meters as "corrupted"). The numerator can be
+    // any byte value; only guard against the shift below overflowing.
+    if (timeSigDenominator > 7)
     {
         errorFail(SMF_CORRUPTED_MIDI_FILE);
         return;


### PR DESCRIPTION
## Problem

PianoBooster shows *"MIDI file … is corrupted"* and refuses to open some Standard MIDI Files that play correctly in every other player.

## Cause

`CMidiTrack::readTimeSignatureEvent()` calls `errorFail(SMF_CORRUPTED_MIDI_FILE)` whenever a time signature has:

- a denominator exponent `>= 5` (i.e. a 1/32-note meter or finer), or
- a numerator `> 20`.

Both are valid per the SMF spec and occur in real music — e.g. expressive piano arrangements that briefly switch to a 1/32 meter. One concrete example: a widely-shared *Für Elise* arrangement contains a `13/32` time-signature change, which made PianoBooster reject the whole file.

## Fix

Allow denominator exponents up to 7 (1/128 — still small enough to keep the `1 << denominator` shift safe) and accept any numerator value.

## Testing

Built with Qt6 on Ubuntu 24.04. The Für Elise arrangement above failed to load before (the parser errored exactly at the time-signature event); after the change it loads and plays correctly. Files without unusual meters are unaffected.
